### PR TITLE
docs+examples: README, quickstart notebook, 3 examples, 4 guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Foundation client infrastructure: `CerberusClient`, `AsyncCerberusClient`, `BaseResource`, `AsyncBaseResource`.
 - API-key auth via `httpx.Auth` (`Authorization: Bearer <key>`).
 - Configurable retry with exponential backoff + jitter, honoring `Retry-After`.
-- Typed error hierarchy parsing RFC 7807 problem documents.
+- Typed error hierarchy parsing RFC 7807 problem documents (`CerberusAPIError`, `AuthError`,
+  `ValidationError`, `QuotaError`, `RateLimitError`, `ServerError`).
 - Pytest fixtures (`sync_client`, `async_client`, `responses_mock`, `problem_json`) for downstream resource modules.
 - CI matrix (Python 3.10 / 3.11 / 3.12) with `pytest`, `ruff`, `mypy --strict`.
 - Release workflow: TestPyPI for `*-rc*`/`*-beta*`/`*-alpha*` tags, PyPI for stable `v*` tags.
+- Developer-experience layer:
+  - `examples/kyb_quickstart.py` — CLI KYB walkthrough (entity + material events + sanctions
+    + directors + regulations) with optional `rich` rendering.
+  - `examples/monitor_portfolio.py` — async polling monitor for a CSV of RUTs, logging new
+    material-event deltas; handles `RateLimitError`, graceful SIGINT/SIGTERM shutdown.
+  - `examples/webhook_handler.py` — FastAPI receiver with HMAC-SHA256 signature verification,
+    replay-window defense, and a routing table for `material_event.published` / `sanction.added`.
+  - `examples/notebooks/01-kyb-quickstart.ipynb` — narrated Jupyter version of the quickstart.
+  - `README.md` with install/quickstart/auth/retries/errors/async/pagination overview.
+  - `docs/quickstart.md`, `docs/auth.md`, `docs/errors.md`, `docs/pagination.md` — Mintlify-ready
+    guides consumed by the P7 dev portal.
+
+### Known gaps (rc1 → GA)
+- Resource namespaces (`client.entities`, `client.persons`, `client.material_events`,
+  `client.sanctions`, `client.registries`, `client.regulations`) land in feat/resources-1
+  and feat/resources-2 before the `v0.1.0` GA tag. Until then, examples and notebooks use the
+  low-level `client._request(method, path, *, params=..., json=...)` surface; every such call
+  is tagged `TODO(#P4-B-merge)` for surgical replacement once the resources PRs land.
 
 [v0.1.0-rc1]: https://github.com/l0rdbarcsacs/cerberus-sdk-python/releases/tag/v0.1.0-rc1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # cerberus-compliance
 
-Official Python SDK for the **Cerberus Compliance API** (Chile RegTech).
+Official Python SDK for the **Cerberus Compliance API** — a Chile RegTech platform for
+KYB (Know Your Business), AML/sanctions screening, CMF material-event feeds, and
+regulatory-registry lookups.
 
-> Status: `v0.1.0-rc1` — foundation only. Full resource coverage shipped by Instances B/C/D in feat/resources-1, feat/resources-2, feat/dx-examples.
+[![PyPI version](https://img.shields.io/pypi/v/cerberus-compliance.svg)](https://pypi.org/project/cerberus-compliance)
+[![Python versions](https://img.shields.io/pypi/pyversions/cerberus-compliance.svg)](https://pypi.org/project/cerberus-compliance)
+[![CI](https://img.shields.io/github/actions/workflow/status/l0rdbarcsacs/cerberus-sdk-python/ci.yml?branch=main)](https://github.com/l0rdbarcsacs/cerberus-sdk-python/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+The SDK wraps the Cerberus REST API with a small, typed, production-shaped surface:
+
+- Synchronous (`CerberusClient`) and asynchronous (`AsyncCerberusClient`) clients sharing
+  the same API and keyword arguments.
+- Typed, granular exception hierarchy (`AuthError`, `ValidationError`, `QuotaError`,
+  `RateLimitError`, `ServerError`) carrying the RFC 7807 problem document and the
+  `X-Request-Id` header.
+- Configurable retries with exponential backoff, jitter, and `Retry-After` honoring.
+- Cursor-pagination helpers (`iter_all`) that transparently chase the `next` token.
+- Bearer API-key auth via the `CERBERUS_API_KEY` environment variable by default.
+- `py.typed` marker — strict `mypy` compatible.
 
 ## Install
 
@@ -10,17 +27,148 @@ Official Python SDK for the **Cerberus Compliance API** (Chile RegTech).
 pip install cerberus-compliance
 ```
 
-## Quickstart
+```bash
+uv add cerberus-compliance
+```
+
+Requires **Python 3.10+**. Core dependencies: `httpx>=0.27,<1.0`, `pydantic>=2.6,<3.0`.
+
+## 30-second quickstart
+
+```python
+import os
+from cerberus_compliance import CerberusClient
+
+with CerberusClient(api_key=os.environ["CERBERUS_API_KEY"]) as client:
+    # Once v0.1.0 GA lands resources will be at client.entities.get(...)
+    entity = client._request("GET", "/entities", params={"rut": "76.086.428-5", "limit": 1})
+    print(entity["data"][0]["legal_name"])
+```
+
+The constructor reads `CERBERUS_API_KEY` from the environment when `api_key=` is omitted,
+so in typical deployments you can write `CerberusClient()` with no arguments.
+
+## Authentication
+
+The SDK authenticates with a bearer API key. Resolution order:
+
+1. `api_key=` constructor argument.
+2. `CERBERUS_API_KEY` environment variable.
+3. Otherwise raise `ValueError`.
 
 ```python
 from cerberus_compliance import CerberusClient
 
-client = CerberusClient(api_key="ck_live_...")  # or env CERBERUS_API_KEY
-
-# Sub-resources are wired by Instances B/C — see CHANGELOG once published.
+client = CerberusClient()                       # reads CERBERUS_API_KEY
+client = CerberusClient(api_key="ck_live_...")  # explicit override
 ```
 
-See `docs/HANDOFF_A.md` for the foundation handoff and the parallel-instance contract.
+See [`docs/auth.md`](./docs/auth.md) for key rotation, custom base URLs, and secret
+hygiene.
+
+## Retries
+
+Every transient failure (HTTP 429, 500, 502, 503, 504 and transport errors) is retried
+with exponential backoff + jitter. Defaults:
+
+```python
+RetryConfig(max_attempts=3, base_delay_ms=200, max_delay_ms=10_000,
+            retry_on=(429, 500, 502, 503, 504), jitter=True)
+```
+
+Customize per client:
+
+```python
+from cerberus_compliance import CerberusClient
+from cerberus_compliance.retry import RetryConfig
+
+client = CerberusClient(retry=RetryConfig(max_attempts=5, base_delay_ms=500))
+```
+
+When the retry budget is exhausted the original `CerberusAPIError` (or transport error)
+is raised to the caller.
+
+## Errors
+
+All non-2xx responses raise a subclass of `CerberusAPIError`. Each exception carries
+`.status`, `.problem` (the RFC 7807 body as a `dict`), `.request_id`, and convenience
+`.title` / `.detail` / `.type` / `.instance` properties. The hierarchy is:
+`AuthError` (401/403), `QuotaError` (402), `ValidationError` (422, with `.errors`),
+`RateLimitError` (429, with `.retry_after`), `ServerError` (5xx).
+
+See [`docs/errors.md`](./docs/errors.md) for recipes and support-ticket guidance.
+
+## Async
+
+```python
+import asyncio
+from cerberus_compliance import AsyncCerberusClient
+
+async def main() -> None:
+    async with AsyncCerberusClient() as client:
+        data = await client._request("GET", "/entities", params={"rut": "76.086.428-5"})
+        print(data["data"][0]["legal_name"])
+
+asyncio.run(main())
+```
+
+`AsyncCerberusClient` mirrors the sync client 1:1 — same constructor arguments, same
+retry policy, same exception hierarchy.
+
+## Pagination
+
+All list endpoints return a `{"data": [...], "next": "<cursor>" | null}` envelope.
+The SDK ships an `iter_all` helper on every list resource that chases cursors lazily,
+so you never have to hold a full result set in memory. See
+[`docs/pagination.md`](./docs/pagination.md) for the manual-loop pattern and the
+`iter_all` API.
+
+## Examples
+
+- [`examples/kyb_quickstart.py`](./examples/kyb_quickstart.py) — CLI: resolve an entity
+  by RUT, then print its recent facts, sanctions, directors, and regulatory profile.
+- [`examples/monitor_portfolio.py`](./examples/monitor_portfolio.py) — async polling
+  over a CSV of RUTs, logs new material events on each tick with graceful shutdown.
+- [`examples/webhook_handler.py`](./examples/webhook_handler.py) — FastAPI receiver
+  with HMAC-SHA256 signature verification and replay protection.
+- [`examples/notebooks/01-kyb-quickstart.ipynb`](./examples/notebooks/01-kyb-quickstart.ipynb)
+  — narrated Jupyter version of the quickstart, ideal for analyst workflows.
+
+## Status / roadmap
+
+`v0.1.0-rc1` is a release candidate. The transport, auth, retry, error, and pagination
+foundations are final; typed resource namespaces land across the following milestones:
+
+| Surface                          | Status         |
+|----------------------------------|----------------|
+| `CerberusClient` / `AsyncCerberusClient` | Shipped in rc1 |
+| `CerberusAPIError` hierarchy      | Shipped in rc1 |
+| `RetryConfig`, `ApiKeyAuth`       | Shipped in rc1 |
+| `client.entities`, `client.persons`, `client.material_events` | Arriving in v0.1.0 GA |
+| `client.sanctions`, `client.registries`, `client.regulations` | Arriving in v0.1.0 GA |
+| Webhook signature helper (SDK-side) | v0.2.0 |
+
+In rc1 you can always fall back to the low-level `client._request(method, path, ...)`
+transport, which returns the parsed JSON body as a `dict`.
+
+## Contributing
+
+```bash
+git clone https://github.com/l0rdbarcsacs/cerberus-sdk-python.git
+cd cerberus-sdk-python
+pip install -e ".[dev]"
+pytest -q
+```
+
+Changelog: [`CHANGELOG.md`](./CHANGELOG.md).
+Report issues at <https://github.com/l0rdbarcsacs/cerberus-sdk-python/issues>.
+
+## Links
+
+- PyPI: <https://pypi.org/project/cerberus-compliance>
+- Repository: <https://github.com/l0rdbarcsacs/cerberus-sdk-python>
+- Developer portal: <https://developers.cerberus.cl>
+- Changelog: [`CHANGELOG.md`](./CHANGELOG.md)
 
 ## License
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,139 @@
+---
+title: "Authentication"
+description: "API keys, environment variables, and secret hygiene for the Cerberus SDK."
+---
+
+# Authentication
+
+The Cerberus Compliance API uses **bearer API keys**. Every outbound request made by
+`CerberusClient` and `AsyncCerberusClient` carries an
+`Authorization: Bearer <api_key>` header, plus a
+`User-Agent: cerberus-compliance/<version>` identifying the SDK.
+
+## API keys overview
+
+- Keys are issued per tenant from the Cerberus admin dashboard.
+- The first 8 characters of a key form a **stable, non-secret prefix** that is safe to
+  log and attach to audit trails (for example `ck_live_`). The remainder is the secret
+  material — never log it, never ship it to the browser.
+- Key rotation is handled server-side: existing keys keep working until you revoke
+  them, so you can overlap old and new keys during a deploy.
+- The SDK never caches the key to disk. It is held on the `CerberusClient` instance
+  only.
+
+## The `CERBERUS_API_KEY` environment variable
+
+By default the SDK reads the API key from the `CERBERUS_API_KEY` environment variable.
+This is the recommended production pattern — keys live in your secret manager and are
+injected into the process environment at boot.
+
+```python
+from cerberus_compliance import CerberusClient
+
+client = CerberusClient()  # reads $CERBERUS_API_KEY
+```
+
+If neither an explicit `api_key=` argument nor the `CERBERUS_API_KEY` environment
+variable is set, the constructor raises `ValueError`:
+
+```text
+ValueError: Cerberus API key not provided. Pass api_key= or set CERBERUS_API_KEY.
+```
+
+The environment-variable name is also exported as a constant in case your application
+wants to reference it programmatically:
+
+```python
+from cerberus_compliance.auth import API_KEY_ENV_VAR  # "CERBERUS_API_KEY"
+```
+
+## Passing a key explicitly
+
+For one-off scripts, testing, or multi-tenant processes that juggle several keys,
+pass the key directly:
+
+```python
+from cerberus_compliance import CerberusClient
+
+client = CerberusClient(api_key="ck_live_...")
+```
+
+Explicit arguments always win over the environment variable.
+
+## Custom base URL
+
+For staging environments, regional endpoints, or local mock servers, override
+`base_url`:
+
+```python
+from cerberus_compliance import CerberusClient
+
+client = CerberusClient(
+    api_key="ck_test_...",
+    base_url="https://staging-api.cerberus.cl/v1",
+)
+```
+
+The default is `https://api.cerberus.cl/v1`. A trailing slash on `base_url` is
+stripped automatically — both `https://example.com/v1` and `https://example.com/v1/`
+work identically. During unit tests you can point the SDK at a `respx` or
+`http.server` mock running on `http://127.0.0.1:<port>`.
+
+## Custom `httpx.Client` / `httpx.AsyncClient`
+
+For advanced deployments — corporate proxies, custom trust stores, mutual TLS, request
+tracing — inject your own `httpx` client. The SDK will reuse it verbatim (including any
+transport, proxy, or event hooks you configure) and apply its own `ApiKeyAuth` on top.
+
+```python
+import httpx
+from cerberus_compliance import CerberusClient
+
+transport = httpx.HTTPTransport(proxy="http://corp-proxy:3128", retries=0)
+my_http = httpx.Client(
+    base_url="https://api.cerberus.cl/v1",
+    timeout=30.0,
+    transport=transport,
+    verify="/etc/ssl/corp-ca-bundle.pem",
+)
+
+client = CerberusClient(api_key="ck_live_...", http_client=my_http)
+```
+
+The same hook exists on `AsyncCerberusClient` via `http_client=` accepting an
+`httpx.AsyncClient`. When you supply your own client you also own its lifecycle —
+`CerberusClient.close()` calls `http_client.close()`, so the SDK's context-manager
+semantics still work, but if you share the same `httpx` client across multiple SDK
+instances you should pass `close_httpx=False` at your own application layer.
+
+## Rotating keys
+
+Rotate early, rotate often. The recommended pattern:
+
+1. **Create** a new API key in the admin dashboard. Note both its prefix and its
+   secret.
+2. **Deploy** the new secret to your secret manager and your running services. Leave
+   the old key active during this window.
+3. **Verify** the new key is serving live traffic (check the prefix in your request
+   logs).
+4. **Revoke** the old key from the admin dashboard.
+
+The Cerberus platform honors a **30-day grace period** on revoked keys: once you
+delete a key it continues to authenticate for up to 30 days, returning a
+`Deprecation` header on every response so your observability stack can surface
+lingering usage. Treat this as a safety net, not a migration strategy.
+
+## Secret hygiene
+
+- **Never** commit keys to the repository. Add them to `.gitignore` patterns and scan
+  history with tooling such as `gitleaks` or `trufflehog`.
+- Prefer **short-lived keys for CI**. Issue a CI-only key with narrow scopes, rotate
+  on schedule (e.g. monthly), and revoke immediately on any compromise signal.
+- Store production keys in a dedicated **secret manager**: AWS Secrets Manager,
+  HashiCorp Vault, GCP Secret Manager, Azure Key Vault, 1Password, or Doppler.
+  Application code reads from the manager at boot, not from config files baked into
+  the container image.
+- Log **prefixes only**. The first 8 characters uniquely identify a key for support
+  purposes without leaking secret material.
+- For operational references to the key-lifecycle policy, see
+  `docs/legal/01-rat/act-006-api-keys.md` in the main Cerberus monorepo.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,183 @@
+---
+title: "Errors"
+description: "The CerberusAPIError hierarchy, RFC 7807 problem details, and common recipes."
+---
+
+# Errors
+
+Every non-2xx HTTP response is translated into a typed exception. The SDK never
+returns an error dict — any time a call returns normally, you can trust the body is a
+successful payload.
+
+## The hierarchy
+
+```text
+CerberusAPIError
+├── AuthError          (401, 403)
+├── QuotaError         (402)
+├── ValidationError    (422) — .errors: list[dict]
+├── RateLimitError     (429) — .retry_after: float | None
+└── ServerError        (5xx)
+```
+
+All five concrete subclasses are re-exported from the top-level package:
+
+```python
+from cerberus_compliance import (
+    CerberusAPIError,
+    AuthError,
+    QuotaError,
+    ValidationError,
+    RateLimitError,
+    ServerError,
+)
+```
+
+Status codes that fall outside the dispatch table (for example an unexpected 418)
+raise the base `CerberusAPIError` directly. Any 5xx status that is not otherwise
+mapped resolves to `ServerError`.
+
+## Fields on every error
+
+Every `CerberusAPIError` exposes the following:
+
+| Attribute     | Type                 | Description                                                   |
+|---------------|----------------------|---------------------------------------------------------------|
+| `.status`     | `int`                | HTTP status code returned by the API.                         |
+| `.problem`    | `dict[str, Any]`     | Full RFC 7807 problem document (see below).                   |
+| `.request_id` | `str \| None`        | Value of the `X-Request-Id` response header.                  |
+| `.title`      | `str` (property)     | `problem["title"]`, falling back to the HTTP reason phrase.   |
+| `.detail`     | `str \| None` (prop) | `problem["detail"]`, or `None` when absent.                   |
+| `.type`       | `str` (property)     | `problem["type"]`, defaulting to `"about:blank"` per RFC 7807.|
+| `.instance`   | `str \| None` (prop) | `problem["instance"]`, or `None` when absent.                 |
+
+`str(exc)` renders a compact, log-friendly line, for example:
+
+```text
+422 Unprocessable Entity: rut is not a valid Chilean tax id [request_id=req_01HW...]
+```
+
+## The `problem` dict
+
+The Cerberus API follows [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)
+(`application/problem+json`). A typical body looks like:
+
+```json
+{
+  "type": "https://developers.cerberus.cl/problems/validation",
+  "title": "Unprocessable Entity",
+  "status": 422,
+  "detail": "rut is not a valid Chilean tax id",
+  "instance": "/v1/entities",
+  "errors": [
+    {"field": "rut", "code": "invalid_format", "message": "must include check digit"}
+  ]
+}
+```
+
+The SDK exposes the full dict as `exc.problem`, so any extra fields the server chose
+to include (vendor extensions, tenant ids, trace ids) remain accessible without
+parsing the body yourself.
+
+The SDK is **defensive**: if the server returns an empty body, malformed JSON, a JSON
+array, or a plain-text error, `.problem` is still a `dict` (with a synthetic `title`
+populated from the HTTP reason phrase). You never have to null-check it.
+
+## Handling specific errors
+
+### Detecting a bad API key
+
+```python
+from cerberus_compliance import CerberusClient, AuthError
+
+try:
+    with CerberusClient() as client:
+        client._request("GET", "/entities", params={"limit": 1})
+except AuthError as exc:
+    raise SystemExit(
+        f"Cerberus rejected the API key ({exc.status} {exc.title}); "
+        f"check CERBERUS_API_KEY. request_id={exc.request_id}"
+    ) from exc
+```
+
+`AuthError` covers both **401** (invalid / missing key) and **403** (key lacks the
+scope needed for the endpoint). Read `exc.detail` to distinguish.
+
+### Handling a rate limit
+
+```python
+import time
+from cerberus_compliance import CerberusClient, RateLimitError
+
+with CerberusClient() as client:
+    try:
+        client._request("GET", "/material_events", params={"limit": 100})
+    except RateLimitError as exc:
+        time.sleep(exc.retry_after or 5)
+```
+
+`exc.retry_after` is a parsed `float` (seconds-from-now) derived from the
+`Retry-After` header. It accepts both the delta-seconds form (`"60"`) and the
+HTTP-date form (`"Wed, 21 Oct 2026 07:28:00 GMT"`), and is `None` if the header was
+missing or unparseable.
+
+### Inspecting validation errors
+
+```python
+from cerberus_compliance import CerberusClient, ValidationError
+
+with CerberusClient() as client:
+    try:
+        client._request("GET", "/entities", params={"rut": "not-a-rut"})
+    except ValidationError as exc:
+        for err in exc.errors:
+            print(f"{err.get('field')}: {err.get('code')} — {err.get('message')}")
+```
+
+`exc.errors` is the field-level list from `problem["errors"]`, filtered to
+dict-shaped entries. It is always a list (empty when the server omitted the field),
+so you can iterate without a null check.
+
+## Retries vs raises
+
+`CerberusClient` retries transient failures **before** raising. The default
+`RetryConfig` retries HTTP **429, 500, 502, 503, 504** and transport-layer errors
+with exponential backoff (+ jitter) up to `max_attempts=3`.
+
+That means:
+
+- When your code sees `RateLimitError` or `ServerError`, the SDK has **already**
+  retried `max_attempts - 1` times and exhausted its budget. Your exception handler
+  runs only for the final failure.
+- `AuthError`, `QuotaError`, and `ValidationError` are **not** retried — they reflect
+  caller-side problems (bad credentials, exhausted quota, invalid input) that a retry
+  cannot fix. They are raised on the first response.
+- When the server returns a `Retry-After` header on a 429, the SDK uses its value to
+  compute the sleep instead of the exponential schedule (capped by
+  `max_delay_ms`).
+
+Tune the policy via `CerberusClient(retry=RetryConfig(...))` — see the README's
+"Retries" section and the `cerberus_compliance.retry` module docstrings.
+
+## Using `request_id` for support
+
+Every raised `CerberusAPIError` preserves the `X-Request-Id` header returned by the
+Cerberus API gateway. When you file a support ticket, paste this id verbatim —
+Cerberus operations can trace exactly that request end-to-end, across the gateway,
+the service that handled it, and the downstream regulatory source. Example triage
+line you should aim to log:
+
+```python
+logger.error(
+    "cerberus.api_error",
+    extra={
+        "status": exc.status,
+        "title": exc.title,
+        "detail": exc.detail,
+        "request_id": exc.request_id,
+    },
+)
+```
+
+Reports with a `request_id` typically resolve an order of magnitude faster than
+reports with a copy-pasted stack trace alone.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,135 @@
+---
+title: "Pagination"
+description: "Cursor pagination conventions and the SDK's iter_all helper."
+---
+
+# Pagination
+
+All Cerberus list endpoints (`/entities`, `/material_events`, `/sanctions`, …) use
+**cursor pagination** with a uniform envelope. The SDK exposes both a manual-loop
+pattern and a lazy `iter_all` helper so you can pick the ergonomics that fit your
+call site.
+
+## Envelope format
+
+Every list response looks like this:
+
+```json
+{
+  "data": [
+    { "id": "ent_01HW...", "legal_name": "ACME SpA", "rut": "76.086.428-5" },
+    { "id": "ent_01HX...", "legal_name": "BETA SpA", "rut": "77.123.456-7" }
+  ],
+  "next": "eyJhZnRlciI6IjIwMjYtMDQtMjNUMTk6MDA6MDBaIn0"
+}
+```
+
+- `data` — the page of results (always a JSON array; may be empty).
+- `next` — an **opaque** cursor. Pass it back as `?cursor=<next>` on the follow-up
+  request to retrieve the next page. When there are no more results, `next` is either
+  `null`, omitted entirely, or an empty string.
+
+Some endpoints also include a `page` object with metadata (page size, total hints).
+Treat those fields as best-effort — production code should rely on `data` and `next`
+only.
+
+## Manual pagination
+
+With only `_request`, the loop is short and explicit. This is the shape you use today
+in v0.1.0-rc1:
+
+```python
+from typing import Any
+from cerberus_compliance import CerberusClient
+
+def fetch_all_material_events(client: CerberusClient, since: str) -> list[dict[str, Any]]:
+    collected: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"limit": 50, "since": since}
+
+    while True:
+        response = client._request("GET", "/material_events", params=params)
+        collected.extend(response.get("data", []))
+
+        next_token = response.get("next")
+        if not isinstance(next_token, str) or not next_token:
+            break
+        # Chase the cursor. Keep the original filters — some endpoints require them.
+        params = {"cursor": next_token}
+
+    return collected
+```
+
+Notes:
+
+- Check `isinstance(next_token, str) and next_token` — the SDK treats `None`, missing
+  keys, and empty strings identically, but your code should too.
+- Keep page size modest (`limit=50` to `limit=200` are typical) to stay well within
+  the response-size budget.
+
+## With `iter_all`
+
+Once resource namespaces ship in **v0.1.0 GA**, idiomatic iteration becomes a single
+`for` loop:
+
+```python
+from cerberus_compliance import CerberusClient
+
+with CerberusClient() as client:
+    last_seen = "2026-04-23T00:00:00Z"
+    for event in client.material_events.iter_all(since=last_seen):
+        process(event)
+```
+
+Features:
+
+- **Lazy** — one HTTP request per page. Memory usage is bounded by `limit`, not by
+  the total result-set size. You can walk millions of events without OOMing.
+- **Transparent cursor handling** — you never touch the `next` token yourself.
+- **Filter forwarding** — keyword arguments (`since=`, `active=`, `category=`, etc.)
+  are forwarded on every page request, exactly as the underlying endpoint expects.
+- **Early exit** is fine. Break out of the loop whenever you have enough results; the
+  SDK does not prefetch additional pages.
+
+## Async iteration
+
+The async client exposes the same helper as an **async iterator**:
+
+```python
+import asyncio
+from cerberus_compliance import AsyncCerberusClient
+
+async def tail_events(since: str) -> None:
+    async with AsyncCerberusClient() as client:
+        async for event in client.material_events.iter_all(since=since):
+            await handle(event)
+
+asyncio.run(tail_events("2026-04-23T00:00:00Z"))
+```
+
+Under the hood each page is a single `await` on `_request`, so back-pressure (via
+`httpx`'s connection pool) works exactly as you would expect.
+
+## Cursor stability
+
+Cursors are **server-issued** and opaque. Two guarantees worth knowing:
+
+1. A cursor is specific to the filter set that produced it. Do not reuse a cursor
+   from one query with a different `since=` or `active=` filter — the server may
+   reject it or return results that no longer match.
+2. Cursors may **expire after roughly 24 hours**. Callers that pause pagination
+   overnight and resume the next day should drop the cursor and re-issue the query
+   with a `since=<timestamp>` filter instead. This is also the right pattern for
+   incremental sync jobs: persist the last processed timestamp, not the last cursor.
+
+## Gotchas
+
+- **Do not construct cursors by hand.** They are opaque tokens (typically
+  base64-encoded JSON, but the scheme may change). Always pass back the exact string
+  the server returned.
+- **Do not mix filters across pages.** Once you have a cursor, the only parameter you
+  need is `cursor=<token>`; the server already remembers the filters.
+- **Empty `data` with a non-null `next` is legal** (rare, but valid). The SDK's
+  `iter_all` handles this correctly — your manual loop should too.
+- **The SDK wraps non-object responses defensively.** If the server returns a bare
+  JSON array at the top level, `_request` wraps it as `{"data": [...]}` with no
+  `next`. Treat it the same as a single-page result.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,118 @@
+---
+title: "Quickstart"
+description: "Install the SDK, authenticate, and make your first call in under 60 seconds."
+---
+
+# Quickstart
+
+This page takes you from a blank shell to a successful API call in about a minute. It
+targets **Python 3.10+** and the official `cerberus-compliance` package on PyPI.
+
+## Install
+
+Pick one of the install flows below. All three install the same wheel.
+
+```bash
+pip install cerberus-compliance
+```
+
+```bash
+uv add cerberus-compliance
+```
+
+For local development (tests, linters, mock-server libraries):
+
+```bash
+pip install "cerberus-compliance[dev]"
+```
+
+The `[dev]` extra pulls in `pytest`, `pytest-asyncio`, `pytest-cov`, `respx`,
+`responses`, `ruff`, `mypy`, and the OpenAPI client generator.
+
+## Get an API key
+
+API keys are scoped to a single tenant and are created from the **Cerberus admin
+dashboard** (available from phase P3 onward). Each key has a public 8-character prefix
+(safe to log — useful for audit trails) and a secret remainder that must be treated as
+a credential.
+
+Export the key as `CERBERUS_API_KEY` before running any snippet on this page:
+
+```bash
+export CERBERUS_API_KEY="ck_live_..."
+```
+
+Never commit an API key. Keep it in a secret manager (AWS Secrets Manager, HashiCorp
+Vault, 1Password, Doppler, etc.) and inject it at runtime. See
+[`docs/auth.md`](./auth.md) for the full guidance.
+
+## First call — sync
+
+```python
+import os
+from cerberus_compliance import CerberusClient, CerberusAPIError
+
+with CerberusClient(api_key=os.environ["CERBERUS_API_KEY"]) as client:
+    try:
+        # Once v0.1.0 GA ships resources will be at client.entities.get(rut=...)
+        response = client._request(
+            "GET",
+            "/entities",
+            params={"rut": "76.086.428-5", "limit": 1},
+        )
+    except CerberusAPIError as exc:
+        print(f"API error {exc.status}: {exc.title} (request_id={exc.request_id})")
+        raise
+
+    entity = response["data"][0]
+    print(entity["legal_name"])
+```
+
+What to notice:
+
+- The client is used as a context manager so the underlying `httpx.Client` is released
+  when the block exits.
+- `_request` returns the parsed JSON body as a `dict`. List endpoints use the
+  `{"data": [...], "next": "<cursor>"}` envelope.
+- Wrapping the call in `try/except CerberusAPIError` is the minimum shape for
+  production code. From day one you get a typed exception with `.status`, `.title`, and
+  `.request_id` attached.
+
+## First call — async
+
+```python
+import asyncio
+import os
+from cerberus_compliance import AsyncCerberusClient, CerberusAPIError
+
+async def main() -> None:
+    async with AsyncCerberusClient(api_key=os.environ["CERBERUS_API_KEY"]) as client:
+        try:
+            response = await client._request(
+                "GET",
+                "/entities",
+                params={"rut": "76.086.428-5", "limit": 1},
+            )
+        except CerberusAPIError as exc:
+            print(f"API error {exc.status}: {exc.title}")
+            raise
+
+        print(response["data"][0]["legal_name"])
+
+asyncio.run(main())
+```
+
+The async client is a strict mirror of the sync one — same constructor keyword
+arguments, same retry policy, same error hierarchy. You can run many requests
+concurrently with `asyncio.gather` once you have the client open.
+
+## Next steps
+
+- [Authentication](./auth.md) — key rotation, staging base URLs, custom `httpx`
+  clients, and secret hygiene.
+- [Errors](./errors.md) — the `CerberusAPIError` hierarchy and handler recipes.
+- [Pagination](./pagination.md) — cursor conventions and the `iter_all` helper.
+- Examples: [`examples/kyb_quickstart.py`](../examples/kyb_quickstart.py),
+  [`examples/monitor_portfolio.py`](../examples/monitor_portfolio.py),
+  [`examples/webhook_handler.py`](../examples/webhook_handler.py),
+  [`examples/notebooks/01-kyb-quickstart.ipynb`](../examples/notebooks/01-kyb-quickstart.ipynb).

--- a/examples/kyb_quickstart.py
+++ b/examples/kyb_quickstart.py
@@ -1,0 +1,400 @@
+"""KYB (Know Your Business) quickstart for the Cerberus Compliance SDK.
+
+Given a Chilean tax id (RUT), resolve the corresponding entity and print a
+human-readable summary covering:
+
+* The entity header (id, legal name, RUT, regulated sector).
+* The five most recent material/essential facts.
+* Currently active sanctions.
+* Directors on record.
+* Regulatory profile (regulator, license, status).
+
+Usage::
+
+    export CERBERUS_API_KEY=ck_live_...
+    python examples/kyb_quickstart.py --rut 76.086.428-5
+
+    # or, equivalently:
+    python -m examples.kyb_quickstart --rut 76.086.428-5
+
+Optional flags ``--base-url`` and ``--api-key`` override the defaults for
+staging / local runs. Install ``rich`` (``pip install rich``) for prettier
+output; plain text is used automatically when ``rich`` is unavailable.
+
+This example targets the foundation-only surface of the SDK (Instance A).
+Once ``feat/resources-1`` (Instance B) lands with typed sub-resource
+accessors, the ``client._request`` calls below should be migrated to
+``client.entities.get(...)``, ``client.entities.material_events.list(...)``,
+etc. — see the ``TODO(#P4-B-merge)`` markers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+
+from cerberus_compliance import (
+    AuthError,
+    CerberusAPIError,
+    CerberusClient,
+    RateLimitError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+
+    _RICH_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency branch
+    Console = None  # type: ignore[assignment, misc]
+    Table = None  # type: ignore[assignment, misc]
+    _RICH_AVAILABLE = False
+
+
+logger = logging.getLogger("cerberus_compliance.examples.kyb_quickstart")
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for the KYB quickstart CLI."""
+    parser = argparse.ArgumentParser(
+        prog="kyb_quickstart",
+        description="KYB quickstart: resolve a Chilean RUT and print a compliance summary.",
+    )
+    parser.add_argument(
+        "--rut",
+        required=True,
+        help="Chilean tax id (RUT) to resolve, e.g. 76.086.428-5.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Override the Cerberus API base URL (defaults to production).",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Cerberus API key. Falls back to the CERBERUS_API_KEY env var.",
+    )
+    return parser
+
+
+# --------------------------------------------------------------------------- #
+# API calls (low-level: use _request until Instance B merges)                 #
+# --------------------------------------------------------------------------- #
+
+
+def _unwrap_list(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract a ``list[dict]`` from a ``{"data": [...]}`` list envelope."""
+    data = payload.get("data", [])
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def resolve_entity(client: CerberusClient, rut: str) -> dict[str, Any] | None:
+    """Resolve the first entity matching ``rut``.
+
+    Returns ``None`` when no entity is found.
+    """
+    # TODO(#P4-B-merge): switch to client.entities.get(rut=...) once feat/resources-1 lands.
+    payload = client._request(
+        "GET",
+        "/entities",
+        params={"rut": rut, "limit": 1},
+    )
+    entities = _unwrap_list(payload)
+    return entities[0] if entities else None
+
+
+def list_material_events(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
+    """Return the five most recent material/essential facts for an entity."""
+    # TODO(#P4-B-merge): switch to client.entities.material_events.list(...) once
+    # feat/resources-1 lands.
+    payload = client._request(
+        "GET",
+        f"/entities/{entity_id}/material_events",
+        params={"limit": 5},
+    )
+    return _unwrap_list(payload)
+
+
+def list_active_sanctions(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
+    """Return the entity's currently active sanctions."""
+    # TODO(#P4-B-merge): switch to client.entities.sanctions.list(active=True) once
+    # feat/resources-1 lands.
+    payload = client._request(
+        "GET",
+        f"/entities/{entity_id}/sanctions",
+        params={"active": "true"},
+    )
+    return _unwrap_list(payload)
+
+
+def list_directors(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
+    """Return the entity's directors on record."""
+    # TODO(#P4-B-merge): switch to client.entities.directors.list(...) once
+    # feat/resources-1 lands.
+    payload = client._request("GET", f"/entities/{entity_id}/directors")
+    return _unwrap_list(payload)
+
+
+def fetch_regulations(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
+    """Return the entity's regulatory profile (regulator, license, status)."""
+    # TODO(#P4-B-merge): switch to client.entities.regulations.list(...) once
+    # feat/resources-1 lands.
+    payload = client._request("GET", f"/entities/{entity_id}/regulations")
+    return _unwrap_list(payload)
+
+
+# --------------------------------------------------------------------------- #
+# Rendering                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _as_str(value: Any) -> str:
+    """Coerce an arbitrary JSON value to a display string."""
+    if value is None:
+        return "-"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return repr(value)
+
+
+def _render_rich(
+    entity: dict[str, Any],
+    events: list[dict[str, Any]],
+    sanctions: list[dict[str, Any]],
+    directors: list[dict[str, Any]],
+    regulations: list[dict[str, Any]],
+) -> None:
+    """Render the KYB summary using the optional ``rich`` library.
+
+    Only invoked when :data:`_RICH_AVAILABLE` is ``True``, so the ``rich``
+    symbols imported at module top are guaranteed to be real classes here.
+    """
+    console = Console()
+
+    header = Table(title="Entity", show_header=False, header_style="bold cyan")
+    header.add_column("Field", style="bold")
+    header.add_column("Value")
+    header.add_row("id", _as_str(entity.get("id")))
+    header.add_row("legal_name", _as_str(entity.get("legal_name") or entity.get("name")))
+    header.add_row("rut", _as_str(entity.get("rut")))
+    header.add_row("sector", _as_str(entity.get("sector")))
+    header.add_row("status", _as_str(entity.get("status")))
+    console.print(header)
+
+    events_table = Table(title="Recent material events (max 5)", header_style="bold magenta")
+    events_table.add_column("date")
+    events_table.add_column("category")
+    events_table.add_column("title", overflow="fold")
+    for event in events:
+        events_table.add_row(
+            _as_str(event.get("event_date") or event.get("date")),
+            _as_str(event.get("category")),
+            _as_str(event.get("title") or event.get("summary")),
+        )
+    if not events:
+        events_table.add_row("-", "-", "(no events)")
+    console.print(events_table)
+
+    sanctions_table = Table(title="Active sanctions", header_style="bold red")
+    sanctions_table.add_column("issued")
+    sanctions_table.add_column("regulator")
+    sanctions_table.add_column("reason", overflow="fold")
+    for sanction in sanctions:
+        sanctions_table.add_row(
+            _as_str(sanction.get("issued_at") or sanction.get("date")),
+            _as_str(sanction.get("regulator")),
+            _as_str(sanction.get("reason") or sanction.get("summary")),
+        )
+    if not sanctions:
+        sanctions_table.add_row("-", "-", "(no active sanctions)")
+    console.print(sanctions_table)
+
+    directors_table = Table(title="Directors", header_style="bold green")
+    directors_table.add_column("name")
+    directors_table.add_column("role")
+    directors_table.add_column("rut")
+    for director in directors:
+        directors_table.add_row(
+            _as_str(director.get("name") or director.get("full_name")),
+            _as_str(director.get("role") or director.get("title")),
+            _as_str(director.get("rut")),
+        )
+    if not directors:
+        directors_table.add_row("-", "-", "(no directors on record)")
+    console.print(directors_table)
+
+    regulations_table = Table(title="Regulatory profile", header_style="bold yellow")
+    regulations_table.add_column("regulator")
+    regulations_table.add_column("license")
+    regulations_table.add_column("status")
+    for regulation in regulations:
+        regulations_table.add_row(
+            _as_str(regulation.get("regulator")),
+            _as_str(regulation.get("license") or regulation.get("license_number")),
+            _as_str(regulation.get("status")),
+        )
+    if not regulations:
+        regulations_table.add_row("-", "-", "(no regulations on record)")
+    console.print(regulations_table)
+
+
+def _render_plain(
+    entity: dict[str, Any],
+    events: list[dict[str, Any]],
+    sanctions: list[dict[str, Any]],
+    directors: list[dict[str, Any]],
+    regulations: list[dict[str, Any]],
+) -> None:
+    """Render the KYB summary as plain text (rich-less fallback)."""
+    lines: list[str] = []
+    lines.append("=" * 72)
+    lines.append("ENTITY")
+    lines.append("-" * 72)
+    lines.append(f"id         : {_as_str(entity.get('id'))}")
+    lines.append(f"legal_name : {_as_str(entity.get('legal_name') or entity.get('name'))}")
+    lines.append(f"rut        : {_as_str(entity.get('rut'))}")
+    lines.append(f"sector     : {_as_str(entity.get('sector'))}")
+    lines.append(f"status     : {_as_str(entity.get('status'))}")
+
+    lines.append("")
+    lines.append("RECENT MATERIAL EVENTS (max 5)")
+    lines.append("-" * 72)
+    if not events:
+        lines.append("  (no events)")
+    for event in events:
+        date = _as_str(event.get("event_date") or event.get("date"))
+        category = _as_str(event.get("category"))
+        title = _as_str(event.get("title") or event.get("summary"))
+        lines.append(f"  [{date}] ({category}) {title}")
+
+    lines.append("")
+    lines.append("ACTIVE SANCTIONS")
+    lines.append("-" * 72)
+    if not sanctions:
+        lines.append("  (no active sanctions)")
+    for sanction in sanctions:
+        issued = _as_str(sanction.get("issued_at") or sanction.get("date"))
+        regulator = _as_str(sanction.get("regulator"))
+        reason = _as_str(sanction.get("reason") or sanction.get("summary"))
+        lines.append(f"  [{issued}] {regulator}: {reason}")
+
+    lines.append("")
+    lines.append("DIRECTORS")
+    lines.append("-" * 72)
+    if not directors:
+        lines.append("  (no directors on record)")
+    for director in directors:
+        name = _as_str(director.get("name") or director.get("full_name"))
+        role = _as_str(director.get("role") or director.get("title"))
+        rut = _as_str(director.get("rut"))
+        lines.append(f"  {name} ({role}) - {rut}")
+
+    lines.append("")
+    lines.append("REGULATORY PROFILE")
+    lines.append("-" * 72)
+    if not regulations:
+        lines.append("  (no regulations on record)")
+    for regulation in regulations:
+        regulator = _as_str(regulation.get("regulator"))
+        license_ = _as_str(regulation.get("license") or regulation.get("license_number"))
+        status = _as_str(regulation.get("status"))
+        lines.append(f"  {regulator} | license={license_} | status={status}")
+
+    lines.append("=" * 72)
+    print("\n".join(lines))  # noqa: T201 - example CLI output
+
+
+def render_summary(
+    entity: dict[str, Any],
+    events: list[dict[str, Any]],
+    sanctions: list[dict[str, Any]],
+    directors: list[dict[str, Any]],
+    regulations: list[dict[str, Any]],
+) -> None:
+    """Render the full KYB summary; uses ``rich`` when available."""
+    if _RICH_AVAILABLE:
+        _render_rich(entity, events, sanctions, directors, regulations)
+    else:
+        _render_plain(entity, events, sanctions, directors, regulations)
+
+
+# --------------------------------------------------------------------------- #
+# Entry point                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _format_error(exc: CerberusAPIError) -> str:
+    """Format a ``CerberusAPIError`` for CLI output, with actionable hints."""
+    if isinstance(exc, AuthError):
+        return (
+            f"authentication failed ({exc.status} {exc.title}); "
+            "check the --api-key flag or the CERBERUS_API_KEY environment variable"
+        )
+    if isinstance(exc, RateLimitError):
+        retry_after = exc.retry_after
+        if retry_after is not None:
+            return f"rate limited (429 {exc.title}); retry after {retry_after:.1f} seconds" + (
+                f" [request_id={exc.request_id}]" if exc.request_id else ""
+            )
+        return f"rate limited (429 {exc.title}); no Retry-After header was returned" + (
+            f" [request_id={exc.request_id}]" if exc.request_id else ""
+        )
+    message = f"API error: {exc}"
+    if exc.request_id and f"request_id={exc.request_id}" not in message:
+        message = f"{message} [request_id={exc.request_id}]"
+    return message
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the KYB quickstart. Returns a POSIX-style exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+    try:
+        client = CerberusClient(api_key=args.api_key, base_url=args.base_url)
+    except ValueError as exc:
+        return _fail(f"configuration error: {exc}")
+
+    try:
+        with client:
+            entity = resolve_entity(client, args.rut)
+            if entity is None:
+                return _fail(f"no entity found for rut={args.rut!r}")
+
+            entity_id = _as_str(entity.get("id"))
+            events = list_material_events(client, entity_id)
+            sanctions = list_active_sanctions(client, entity_id)
+            directors = list_directors(client, entity_id)
+            regulations = fetch_regulations(client, entity_id)
+    except CerberusAPIError as exc:
+        return _fail(_format_error(exc))
+
+    render_summary(entity, events, sanctions, directors, regulations)
+    return 0
+
+
+def _fail(message: str) -> int:
+    """Print ``message`` to stderr and return exit code 1."""
+    print(f"error: {message}", file=sys.stderr)  # noqa: T201 - example CLI output
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/monitor_portfolio.py
+++ b/examples/monitor_portfolio.py
@@ -1,0 +1,434 @@
+"""Async portfolio monitor for the Cerberus Compliance API.
+
+Reads a CSV file of Chilean tax ids (RUTs) and polls the Cerberus
+``/entities/{id}/material_events`` endpoint every ``--interval`` seconds,
+surfacing newly-published essential facts as log lines.
+
+Usage::
+
+    export CERBERUS_API_KEY=ck_live_...
+    python -m examples.monitor_portfolio --csv portfolio.csv --interval 60
+
+The CSV must have a header row containing a ``rut`` column; extra columns
+are ignored. The example resolves each RUT to an entity id via
+``GET /entities?rut=<rut>&limit=1`` on start-up, then enters a polling
+loop that diffs new ``event_id``s against an in-memory per-entity set.
+
+The file is intentionally self-contained so a first-time user can read
+it top-to-bottom. It uses only the public SDK surface currently shipped
+(``AsyncCerberusClient`` and the error hierarchy); once the B/C resource
+sub-accessors land it should migrate to ``client.entities.iter_all(...)``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import logging
+import os
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from cerberus_compliance import (
+    AsyncCerberusClient,
+    AuthError,
+    CerberusAPIError,
+    QuotaError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
+
+__all__ = ["amain", "main"]
+
+logger = logging.getLogger("cerberus.monitor")
+
+DEFAULT_INTERVAL_SECONDS = 60.0
+DEFAULT_MAX_ENTITIES = 50
+DEFAULT_PAGE_LIMIT = 50
+MAX_FOLLOWUP_PAGES = 5
+EXIT_OK = 0
+EXIT_AUTH = 2
+EXIT_USAGE = 64
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI flags into an :class:`argparse.Namespace`.
+
+    Kept separate from :func:`amain` so the CLI surface is trivial to
+    unit-test. ``argparse`` writes to stderr and raises ``SystemExit`` on
+    bad input, which is the behaviour we want for a script entry point.
+    """
+    parser = argparse.ArgumentParser(
+        prog="monitor_portfolio",
+        description=(
+            "Poll the Cerberus Compliance API for new material events "
+            "across a portfolio of Chilean RUTs."
+        ),
+    )
+    parser.add_argument(
+        "--csv",
+        required=True,
+        help="Path to a CSV file with a header row containing a 'rut' column.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=DEFAULT_INTERVAL_SECONDS,
+        help="Seconds between polling ticks (default: 60).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Override the SDK base URL (defaults to the production Cerberus endpoint).",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Cerberus API key. Falls back to the CERBERUS_API_KEY env var.",
+    )
+    parser.add_argument(
+        "--max-entities",
+        type=int,
+        default=DEFAULT_MAX_ENTITIES,
+        help="Sanity cap on how many unique RUTs to poll (default: 50).",
+    )
+    return parser.parse_args(argv)
+
+
+def _read_ruts(csv_path: str, max_entities: int) -> list[str]:
+    """Read unique, non-empty ``rut`` values from a CSV header file.
+
+    Order is preserved (first occurrence wins) so logs stay stable across
+    runs. Raises :class:`ValueError` when the file has no ``rut`` column.
+    """
+    ruts: list[str] = []
+    seen: set[str] = set()
+
+    with open(csv_path, encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None or "rut" not in reader.fieldnames:
+            raise ValueError(f"CSV {csv_path!r} is missing a 'rut' header column")
+
+        for row in reader:
+            raw = (row.get("rut") or "").strip()
+            if not raw or raw in seen:
+                continue
+            seen.add(raw)
+            ruts.append(raw)
+            if len(ruts) >= max_entities:
+                logger.warning(
+                    "truncating portfolio to first %d RUTs (max-entities cap)",
+                    max_entities,
+                )
+                break
+
+    return ruts
+
+
+def _now_utc_iso() -> str:
+    """Return the current UTC instant as an ISO 8601 string with ``Z`` suffix."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+async def _resolve_entity(
+    client: AsyncCerberusClient,
+    rut: str,
+) -> dict[str, Any] | None:
+    """Resolve a single RUT to an entity summary via ``GET /entities``.
+
+    Returns ``None`` when the RUT is unknown, malformed, or the server
+    returns a transient error. The caller logs and moves on — start-up
+    should never abort because one RUT is bad.
+    """
+    try:
+        # TODO(#P4-B-merge): switch to client.entities.iter_all(...) once feat/resources-1 lands.
+        response = await client._request(
+            "GET",
+            "/entities",
+            params={"rut": rut, "limit": 1},
+        )
+    except AuthError:
+        raise
+    except ValidationError as exc:
+        logger.error("invalid rut %s: %s", rut, exc)
+        return None
+    except (QuotaError, RateLimitError, ServerError, CerberusAPIError) as exc:
+        logger.warning("could not resolve rut %s: %s", rut, exc)
+        return None
+
+    data = response.get("data")
+    if not isinstance(data, list) or not data:
+        logger.warning("rut %s not found in Cerberus directory, skipping", rut)
+        return None
+
+    first = data[0]
+    if not isinstance(first, dict):
+        logger.warning("unexpected payload shape for rut %s, skipping", rut)
+        return None
+
+    return first
+
+
+async def _fetch_events(
+    client: AsyncCerberusClient,
+    entity_id: str,
+    since: str | None,
+) -> list[dict[str, Any]]:
+    """Fetch material events for ``entity_id`` published after ``since``.
+
+    Pages manually using the ``{"data": [...], "next": "..."}`` envelope
+    emitted by the API. Follow-up pages are capped at
+    :data:`MAX_FOLLOWUP_PAGES` to bound each tick's work.
+    """
+    params: dict[str, Any] = {"limit": DEFAULT_PAGE_LIMIT}
+    if since is not None:
+        params["since"] = since
+
+    response = await client._request(
+        "GET",
+        f"/entities/{entity_id}/material_events",
+        params=params,
+    )
+
+    collected: list[dict[str, Any]] = []
+    data = response.get("data")
+    if isinstance(data, list):
+        collected.extend(item for item in data if isinstance(item, dict))
+
+    next_token = response.get("next")
+    pages = 0
+    while isinstance(next_token, str) and next_token and pages < MAX_FOLLOWUP_PAGES:
+        pages += 1
+        follow = await client._request(
+            "GET",
+            f"/entities/{entity_id}/material_events",
+            params={"cursor": next_token},
+        )
+        follow_data = follow.get("data")
+        if isinstance(follow_data, list):
+            collected.extend(item for item in follow_data if isinstance(item, dict))
+        next_token = follow.get("next")
+
+    if pages >= MAX_FOLLOWUP_PAGES and isinstance(next_token, str) and next_token:
+        logger.warning(
+            "entity %s still has more pages after %d follow-ups; deferring to next tick",
+            entity_id,
+            MAX_FOLLOWUP_PAGES,
+        )
+
+    return collected
+
+
+async def _poll_entity(
+    client: AsyncCerberusClient,
+    rut: str,
+    entity: dict[str, Any],
+    since: str | None,
+    seen_event_ids: set[str],
+) -> tuple[int, str | None]:
+    """Poll a single entity once.
+
+    Returns a tuple ``(new_events_count, new_since_iso)``. ``new_since_iso``
+    is ``None`` when the request failed for a recoverable reason — the
+    caller then preserves the previous ``since`` value so the next tick
+    re-asks for the same window.
+    """
+    entity_id = entity.get("id")
+    if not isinstance(entity_id, str) or not entity_id:
+        logger.warning("entity for rut %s has no id, skipping", rut)
+        return 0, since
+
+    tick_started_at = _now_utc_iso()
+
+    try:
+        events = await _fetch_events(client, entity_id, since)
+    except RateLimitError as exc:
+        sleep_for = exc.retry_after if exc.retry_after is not None else DEFAULT_INTERVAL_SECONDS
+        logger.warning("rate limited, sleeping %s s", sleep_for)
+        await asyncio.sleep(sleep_for)
+        return 0, None
+    except AuthError:
+        raise
+    except ValidationError as exc:
+        logger.error("validation error polling entity %s (rut=%s): %s", entity_id, rut, exc)
+        return 0, None
+    except (QuotaError, ServerError, CerberusAPIError) as exc:
+        logger.warning("api error polling entity %s (rut=%s): %s", entity_id, rut, exc)
+        return 0, None
+    except OSError as exc:
+        # httpx re-raises low-level network issues as OSError subclasses once
+        # the retry budget is exhausted. Skip this entity for this tick.
+        logger.warning("network error polling entity %s (rut=%s): %s", entity_id, rut, exc)
+        return 0, None
+
+    new_count = 0
+    for event in events:
+        event_id = event.get("event_id") or event.get("id")
+        if not isinstance(event_id, str) or event_id in seen_event_ids:
+            continue
+        seen_event_ids.add(event_id)
+        new_count += 1
+        logger.info(
+            "new event: entity=%s type=%s published=%s",
+            rut,
+            event.get("type"),
+            event.get("published_at"),
+        )
+
+    return new_count, tick_started_at
+
+
+async def _resolve_portfolio(
+    client: AsyncCerberusClient,
+    ruts: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Resolve each RUT to its entity summary, skipping unknown ones."""
+    resolved: dict[str, dict[str, Any]] = {}
+    for rut in ruts:
+        entity = await _resolve_entity(client, rut)
+        if entity is not None:
+            resolved[rut] = entity
+    return resolved
+
+
+async def _run_loop(
+    client: AsyncCerberusClient,
+    portfolio: dict[str, dict[str, Any]],
+    interval: float,
+    stop_event: asyncio.Event,
+) -> None:
+    """Main polling loop. Exits cleanly when ``stop_event`` is set."""
+    seen_events: dict[str, set[str]] = {rut: set() for rut in portfolio}
+    last_poll: dict[str, str | None] = dict.fromkeys(portfolio, None)
+
+    while not stop_event.is_set():
+        tick_started = time.monotonic()
+        new_total = 0
+
+        for rut, entity in portfolio.items():
+            new_count, new_since = await _poll_entity(
+                client,
+                rut,
+                entity,
+                last_poll[rut],
+                seen_events[rut],
+            )
+            new_total += new_count
+            if new_since is not None:
+                last_poll[rut] = new_since
+
+        elapsed = time.monotonic() - tick_started
+        logger.info(
+            "tick: entities=%d new_events=%d elapsed=%.1fs",
+            len(portfolio),
+            new_total,
+            elapsed,
+        )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            continue
+
+
+def _install_signal_handlers(stop_event: asyncio.Event) -> None:
+    """Wire SIGINT/SIGTERM to set the loop's stop event.
+
+    Falls back silently on platforms that don't support
+    ``loop.add_signal_handler`` (notably Windows for SIGTERM).
+    """
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except (NotImplementedError, RuntimeError):
+            # Best-effort: KeyboardInterrupt in amain() is the fallback.
+            continue
+
+
+async def amain(argv: list[str]) -> int:
+    """Async entry point.
+
+    Returns a process exit code: ``0`` on clean shutdown, ``2`` on auth
+    failure (bad API key — no point retrying), ``64`` on usage errors.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    args = _parse_args(argv)
+
+    api_key = args.api_key or os.environ.get("CERBERUS_API_KEY")
+    if not api_key:
+        logger.error(
+            "no API key provided: pass --api-key or set CERBERUS_API_KEY",
+        )
+        return EXIT_USAGE
+
+    try:
+        ruts = _read_ruts(args.csv, args.max_entities)
+    except FileNotFoundError:
+        logger.error("csv file not found: %s", args.csv)
+        return EXIT_USAGE
+    except ValueError as exc:
+        logger.error("%s", exc)
+        return EXIT_USAGE
+
+    if not ruts:
+        logger.error("csv %s contained no RUTs", args.csv)
+        return EXIT_USAGE
+
+    logger.info("loaded %d RUTs from %s", len(ruts), args.csv)
+
+    stop_event = asyncio.Event()
+    _install_signal_handlers(stop_event)
+
+    try:
+        async with AsyncCerberusClient(api_key=api_key, base_url=args.base_url) as client:
+            try:
+                portfolio = await _resolve_portfolio(client, ruts)
+            except AuthError as exc:
+                logger.error("authentication failed while resolving portfolio: %s", exc)
+                return EXIT_AUTH
+
+            if not portfolio:
+                logger.error("no RUTs could be resolved to entities; nothing to poll")
+                return EXIT_USAGE
+
+            logger.info(
+                "resolved %d/%d entities; starting poll loop (interval=%.1fs)",
+                len(portfolio),
+                len(ruts),
+                args.interval,
+            )
+
+            try:
+                await _run_loop(client, portfolio, args.interval, stop_event)
+            except AuthError as exc:
+                logger.error("authentication failed during polling: %s", exc)
+                return EXIT_AUTH
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        logger.info("shutdown")
+        return EXIT_OK
+
+    logger.info("shutdown")
+    return EXIT_OK
+
+
+def main() -> int:
+    """Synchronous entry point used by ``python -m examples.monitor_portfolio``."""
+    try:
+        return asyncio.run(amain(sys.argv[1:]))
+    except KeyboardInterrupt:
+        logger.info("shutdown")
+        return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/notebooks/01-kyb-quickstart.ipynb
+++ b/examples/notebooks/01-kyb-quickstart.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7c504739",
+   "metadata": {},
+   "source": [
+    "# Cerberus Compliance — KYB Quickstart\n",
+    "\n",
+    "**KYB** (Know Your Business) is the regulated practice of verifying a\n",
+    "company's legal identity, ownership structure, and regulatory standing\n",
+    "before onboarding it as a customer or counterparty. In Chile, this means\n",
+    "checking public registries, sanctions lists (OFAC, EU, UN, CMF-ONU),\n",
+    "essential facts published under NCG 30, and the regulatory frameworks the\n",
+    "entity is subject to (Ley 21.521 RPSF, Ley 21.719, NCG 514, etc.).\n",
+    "\n",
+    "This notebook gets you from an API key to useful KYB data in about five\n",
+    "minutes. Each step has a short explanation of *why* before the code, so\n",
+    "it's designed to be read top-to-bottom the first time through.\n",
+    "\n",
+    "> 📘 Full docs at [developers.cerberus.cl](https://developers.cerberus.cl) (dev portal live post-P7)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f594479",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "- **Python 3.10+** (the SDK uses modern type hints and `match` statements).\n",
+    "- The SDK itself: `pip install cerberus-compliance`.\n",
+    "- A Cerberus API key. The client reads it from the `CERBERUS_API_KEY`\n",
+    "  environment variable by default — export it before launching Jupyter,\n",
+    "  or pass `api_key=` explicitly.\n",
+    "- Optional: `pip install rich` for the pretty-printed summary at the end.\n",
+    "  The notebook degrades gracefully to `print()` when `rich` isn't installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc9bc30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the next line on a fresh kernel to install the SDK and the\n",
+    "# optional `rich` dependency. It's commented out so re-running the whole\n",
+    "# notebook doesn't mutate your environment.\n",
+    "# !pip install cerberus-compliance rich"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00b1132c",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Create a client\n",
+    "\n",
+    "`CerberusClient` is the single entry point for the SDK. By default it\n",
+    "reads `CERBERUS_API_KEY` from the environment, but every knob is\n",
+    "overrideable:\n",
+    "\n",
+    "- `api_key=` — override the env var (useful for notebooks with multiple keys).\n",
+    "- `base_url=` — point at staging (`https://api-staging.cerberus.cl/v1`) or a\n",
+    "  local mock server.\n",
+    "- `timeout=`, `max_retries=`, `backoff_factor=` — tune the retry policy\n",
+    "  (exponential backoff with jitter; 429 and 5xx are retried by default)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5683e5ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from cerberus_compliance import CerberusClient\n",
+    "\n",
+    "client = CerberusClient(\n",
+    "    api_key=os.environ.get(\"CERBERUS_API_KEY\", \"ck_demo_replace_me\"),\n",
+    "    base_url=os.environ.get(\"CERBERUS_BASE_URL\", \"https://api.cerberus.cl/v1\"),\n",
+    ")\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8342a35",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Pick a RUT\n",
+    "\n",
+    "The Chilean **RUT** (Rol Único Tributario) is the national tax ID. The\n",
+    "canonical format is `NN.NNN.NNN-D`, where `D` is a verifier digit (`0`–`9`\n",
+    "or `K`). The SDK accepts both the dotted form and the raw digits.\n",
+    "\n",
+    "We'll use **Falabella Retail S.A.** (`76.086.428-5`) as a public example —\n",
+    "it's a listed issuer with plenty of material events and a well-populated\n",
+    "regulatory profile, so every step below will return non-trivial data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88c843b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rut = \"76.086.428-5\"  # Falabella Retail S.A. — public example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14cfe482",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Resolve the entity\n",
+    "\n",
+    "Entities are queried by RUT through `GET /entities?rut=...`. The response\n",
+    "is a standard list envelope:\n",
+    "\n",
+    "```json\n",
+    "{\"data\": [ {\"id\": \"...\", \"legal_name\": \"...\", ...} ], \"next\": null}\n",
+    "```\n",
+    "\n",
+    "For this quickstart we use the low-level `client._request(...)` escape\n",
+    "hatch, which is available today. Once the resources PR lands, the more\n",
+    "ergonomic `client.entities.get(rut=rut)` will replace every `_request`\n",
+    "call in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b4c129a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO(#P4-B-merge): switch to client.entities.get(rut=rut) once feat/resources-1 lands.\n",
+    "response = client._request(\"GET\", \"/entities\", params={\"rut\": rut, \"limit\": 1})\n",
+    "entities = response.get(\"data\", [])\n",
+    "entity = entities[0] if entities else None\n",
+    "entity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "090e0e7e",
+   "metadata": {},
+   "source": [
+    "## Step 4 — List recent essential facts\n",
+    "\n",
+    "Under Chilean securities law (**NCG 30**, issued by the CMF), listed\n",
+    "issuers must disclose *hechos esenciales* — material facts that a\n",
+    "reasonable investor would consider important. These include M&A\n",
+    "announcements, board changes, covenant breaches, dividend decisions, and\n",
+    "material litigation.\n",
+    "\n",
+    "For ongoing KYB monitoring, this feed is the single best signal that\n",
+    "something about a counterparty has changed since you onboarded them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90b5694c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO(#P4-B-merge): switch to client.entities.material_events(id=entity[\"id\"], limit=5).\n",
+    "events_resp = client._request(\n",
+    "    \"GET\",\n",
+    "    f\"/entities/{entity['id']}/material_events\",\n",
+    "    params={\"limit\": 5},\n",
+    ")\n",
+    "events = events_resp.get(\"data\", [])\n",
+    "events"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aed4b9ed",
+   "metadata": {},
+   "source": [
+    "## Step 5 — Active sanctions\n",
+    "\n",
+    "Cerberus aggregates sanctions lists from the major international bodies\n",
+    "and the Chilean regulator:\n",
+    "\n",
+    "- **OFAC** (U.S. Treasury Specially Designated Nationals)\n",
+    "- **EU** consolidated financial sanctions\n",
+    "- **UN** Security Council Consolidated List\n",
+    "- **CMF-ONU** (Chilean CMF's mirror of the UN list, binding locally)\n",
+    "\n",
+    "Passing `active=true` filters out historical and lifted sanctions so you\n",
+    "only see entries that still apply. For audit and historical exposure\n",
+    "reviews, drop the flag to see the full timeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e6279af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO(#P4-B-merge): switch to client.entities.sanctions(id=entity[\"id\"], active=True).\n",
+    "sanctions_resp = client._request(\n",
+    "    \"GET\",\n",
+    "    f\"/entities/{entity['id']}/sanctions\",\n",
+    "    params={\"active\": \"true\"},\n",
+    ")\n",
+    "sanctions = sanctions_resp.get(\"data\", [])\n",
+    "sanctions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33c10684",
+   "metadata": {},
+   "source": [
+    "## Step 6 — Regulatory profile\n",
+    "\n",
+    "The `regulations` endpoint surfaces the frameworks an entity is subject\n",
+    "to. For a Chilean financial counterparty that typically includes:\n",
+    "\n",
+    "- **Ley 21.521 (Fintec/RPSF)** — Registro de Prestadores de Servicios\n",
+    "  Financieros, the fintech perimeter law.\n",
+    "- **Ley 21.719 (Datos Personales)** — the 2024 data protection overhaul.\n",
+    "- **NCG 514** — operational risk and cyber resilience for supervised entities.\n",
+    "\n",
+    "Each item includes the obligations triggered, the supervising body, and\n",
+    "any active enforcement actions. It's the fastest way to scope a\n",
+    "compliance due-diligence review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "908b5e3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO(#P4-B-merge): switch to client.entities.regulations(id=entity[\"id\"]).\n",
+    "regs_resp = client._request(\"GET\", f\"/entities/{entity['id']}/regulations\")\n",
+    "regulations = regs_resp.get(\"data\", [])\n",
+    "regulations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b5a184d",
+   "metadata": {},
+   "source": [
+    "## Step 7 — Pretty-print with `rich` (optional)\n",
+    "\n",
+    "[`rich`](https://github.com/Textualize/rich) isn't a hard dependency of\n",
+    "the SDK, but it makes ad-hoc exploration much nicer. The cell below\n",
+    "attempts the import and falls back to plain `print()` when `rich` is\n",
+    "absent, so it works either way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "921cae9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from rich.console import Console\n",
+    "    from rich.table import Table\n",
+    "\n",
+    "    console = Console()\n",
+    "    table = Table(title=f\"KYB profile — {entity['legal_name']} ({rut})\")\n",
+    "    table.add_column(\"Metric\")\n",
+    "    table.add_column(\"Value\")\n",
+    "    table.add_row(\"Material events (last 5)\", str(len(events)))\n",
+    "    table.add_row(\"Active sanctions\", str(len(sanctions)))\n",
+    "    table.add_row(\"Regulatory frameworks\", str(len(regulations)))\n",
+    "    console.print(table)\n",
+    "except ImportError:\n",
+    "    print(f\"KYB profile — {entity['legal_name']} ({rut})\")  # noqa: T201\n",
+    "    print(f\"  material events (last 5): {len(events)}\")  # noqa: T201\n",
+    "    print(f\"  active sanctions: {len(sanctions)}\")  # noqa: T201\n",
+    "    print(f\"  regulatory frameworks: {len(regulations)}\")  # noqa: T201"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "747a2316",
+   "metadata": {},
+   "source": [
+    "## Clean up\n",
+    "\n",
+    "`CerberusClient` is a context manager. This notebook created one *outside*\n",
+    "a `with` block on purpose — it lets you re-run individual cells without\n",
+    "rebuilding the HTTP session each time, which is great for experimentation.\n",
+    "\n",
+    "In production, prefer the context-manager form so the underlying\n",
+    "connection pool is always released cleanly:\n",
+    "\n",
+    "```python\n",
+    "with CerberusClient() as client:\n",
+    "    response = client._request(\"GET\", \"/entities\", params={\"rut\": rut})\n",
+    "```\n",
+    "\n",
+    "When used outside a `with` block, call `.close()` explicitly before the\n",
+    "kernel shuts down."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "786f86a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c63767d4",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "Other examples in the repository:\n",
+    "\n",
+    "- [`examples/kyb_quickstart.py`](../kyb_quickstart.py) — the CLI version\n",
+    "  of this notebook, good for scripting and CI smoke tests.\n",
+    "- [`examples/monitor_portfolio.py`](../monitor_portfolio.py) — a polling\n",
+    "  workflow that watches a list of RUTs for new material events.\n",
+    "- [`examples/webhook_handler.py`](../webhook_handler.py) — a push-based\n",
+    "  FastAPI receiver with signature verification.\n",
+    "\n",
+    "Docs (written alongside this notebook):\n",
+    "\n",
+    "- [`docs/quickstart.md`](../../docs/quickstart.md)\n",
+    "- [`docs/auth.md`](../../docs/auth.md)\n",
+    "- [`docs/errors.md`](../../docs/errors.md)\n",
+    "- [`docs/pagination.md`](../../docs/pagination.md)\n",
+    "\n",
+    "And the dev portal placeholder (live post-P7):\n",
+    "[developers.cerberus.cl](https://developers.cerberus.cl)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/webhook_handler.py
+++ b/examples/webhook_handler.py
@@ -1,0 +1,301 @@
+"""FastAPI webhook receiver for Cerberus Compliance outbound events.
+
+This example demonstrates how to verify and dispatch webhooks emitted by the
+Cerberus Compliance platform (P9 in the roadmap). Cerberus signs each webhook
+with HMAC-SHA256 over ``"{timestamp}.{raw_body}"`` using a per-subscription
+secret, and includes the signature in the ``X-Cerberus-Signature`` header
+(``sha256=<hex>``) along with the unix timestamp in ``X-Cerberus-Timestamp``.
+
+Prerequisites (the example keeps these OPTIONAL so that ``import`` succeeds in
+minimal environments)::
+
+    pip install fastapi uvicorn
+
+Environment variables:
+
+* ``CERBERUS_WEBHOOK_SECRET`` (required at runtime) — the shared secret issued
+  by Cerberus when you create a webhook subscription.
+* ``CERBERUS_WEBHOOK_MAX_SKEW_SECONDS`` (optional, default ``300``) — maximum
+  clock drift allowed between the webhook timestamp and the receiver, in
+  seconds. Requests outside this window are rejected to defend against replay.
+
+Run it locally::
+
+    export CERBERUS_WEBHOOK_SECRET="whsec_..."
+    python -m examples.webhook_handler
+    # -> listens on http://0.0.0.0:8000/webhooks/cerberus
+
+Example curl invocation (payload, timestamp, and signature must all match)::
+
+    BODY='{"id":"evt_1","type":"sanction.added","occurred_at":"2026-01-01T00:00:00Z","data":{"entity_id":"ent_42"}}'
+    TS=$(date +%s)
+    SIG=$(printf "%s.%s" "$TS" "$BODY" | openssl dgst -sha256 -hmac "$CERBERUS_WEBHOOK_SECRET" | awk '{print $2}')
+    curl -X POST http://localhost:8000/webhooks/cerberus \\
+        -H "Content-Type: application/json" \\
+        -H "X-Cerberus-Timestamp: $TS" \\
+        -H "X-Cerberus-Signature: sha256=$SIG" \\
+        -d "$BODY"
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import sys
+import time
+from collections.abc import Callable
+from typing import Any
+
+try:
+    from fastapi import FastAPI, HTTPException, Request, status  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dep for examples
+    FastAPI = None  # type: ignore[assignment,misc]
+    HTTPException = None  # type: ignore[assignment,misc]
+    Request = None  # type: ignore[assignment,misc]
+    status = None  # type: ignore[assignment,misc]
+    _FASTAPI_AVAILABLE = False
+else:
+    _FASTAPI_AVAILABLE = True
+
+from cerberus_compliance import CerberusAPIError  # noqa: F401  # imported for handler extensions
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("cerberus.webhook")
+
+SIGNATURE_PREFIX = "sha256="
+DEFAULT_MAX_SKEW_SECONDS = 300
+
+
+# ---------------------------------------------------------------------------
+# Event handlers (stubs — replace with your own business logic)
+# ---------------------------------------------------------------------------
+
+
+def handle_material_event(event: dict[str, Any]) -> None:
+    """Handle a ``material_event.published`` webhook.
+
+    A material event is a CMF-reportable corporate event (e.g. a board
+    resolution, dividend, or earnings release). In production you would push
+    this into your downstream pipeline (queue, datalake, notification system).
+    """
+    data = event.get("data", {})
+    logger.info(
+        "received %s for entity=%s event_id=%s",
+        event.get("type"),
+        data.get("entity_id"),
+        event.get("id"),
+    )
+
+
+def handle_sanction_added(event: dict[str, Any]) -> None:
+    """Handle a ``sanction.added`` webhook.
+
+    Fires when a monitored entity/person appears on a newly ingested sanctions
+    list (OFAC, UN, EU, CMF). Typical reaction: escalate to compliance ops.
+    """
+    data = event.get("data", {})
+    logger.info(
+        "received %s for entity=%s event_id=%s",
+        event.get("type"),
+        data.get("entity_id"),
+        event.get("id"),
+    )
+
+
+# Dispatch table keyed by event ``type``. Unknown types are ACKed with
+# ``{"status": "ignored"}`` so Cerberus does not schedule retries for events
+# this receiver doesn't care about.
+EventHandler = Callable[[dict[str, Any]], None]
+HANDLERS: dict[str, EventHandler] = {
+    "material_event.published": handle_material_event,
+    "sanction.added": handle_sanction_added,
+}
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+def _verify_signature(
+    *,
+    secret: str,
+    raw_body: bytes,
+    signature_header: str | None,
+    timestamp_header: str | None,
+    max_skew_seconds: int,
+    now: float | None = None,
+) -> None:
+    """Verify the HMAC-SHA256 signature and timestamp freshness.
+
+    Raises :class:`fastapi.HTTPException` with 401 on any failure. Uses
+    :func:`hmac.compare_digest` to avoid timing side-channels.
+    """
+    if HTTPException is None:  # pragma: no cover - guarded by _FASTAPI_AVAILABLE
+        raise RuntimeError("FastAPI is required to verify signatures")
+
+    if not signature_header or not timestamp_header:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        )
+
+    try:
+        ts = int(timestamp_header)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        ) from exc
+
+    current = now if now is not None else time.time()
+    if abs(current - ts) > max_skew_seconds:
+        logger.warning(
+            "rejected webhook: timestamp skew %.0fs exceeds %ds", current - ts, max_skew_seconds
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        )
+
+    if not signature_header.startswith(SIGNATURE_PREFIX):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        )
+    provided = signature_header[len(SIGNATURE_PREFIX) :]
+
+    signed_payload = f"{ts}.{raw_body.decode('utf-8', errors='strict')}".encode()
+    expected = hmac.new(
+        secret.encode("utf-8"), msg=signed_payload, digestmod=hashlib.sha256
+    ).hexdigest()
+
+    if not hmac.compare_digest(expected, provided):
+        logger.warning("rejected webhook: signature mismatch")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid signature",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Configuration + app factory
+# ---------------------------------------------------------------------------
+
+
+def _load_secret() -> str:
+    secret = os.environ.get("CERBERUS_WEBHOOK_SECRET")
+    if not secret:
+        raise RuntimeError("CERBERUS_WEBHOOK_SECRET is required")
+    return secret
+
+
+def _load_max_skew() -> int:
+    raw = os.environ.get("CERBERUS_WEBHOOK_MAX_SKEW_SECONDS")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_SKEW_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            "CERBERUS_WEBHOOK_MAX_SKEW_SECONDS must be an integer number of seconds"
+        ) from exc
+    if value <= 0:
+        raise RuntimeError("CERBERUS_WEBHOOK_MAX_SKEW_SECONDS must be positive")
+    return value
+
+
+def _build_app() -> Any:
+    """Construct the FastAPI app. Only called when FastAPI is importable."""
+    if not _FASTAPI_AVAILABLE:  # pragma: no cover - defensive
+        raise RuntimeError("FastAPI is not installed; run `pip install fastapi`.")
+
+    fastapi_app = FastAPI(title="Cerberus Webhook Receiver", version="0.1.0")
+
+    # Configuration resolved at startup (fail fast on missing secret).
+    state: dict[str, Any] = {}
+
+    @fastapi_app.on_event("startup")
+    async def _configure() -> None:
+        state["secret"] = _load_secret()
+        state["max_skew_seconds"] = _load_max_skew()
+        logger.info("webhook receiver ready: max_skew_seconds=%d", state["max_skew_seconds"])
+
+    @fastapi_app.post("/webhooks/cerberus")
+    async def receive_webhook(request: Request) -> dict[str, str]:
+        raw_body = await request.body()
+
+        _verify_signature(
+            secret=state["secret"],
+            raw_body=raw_body,
+            signature_header=request.headers.get("X-Cerberus-Signature"),
+            timestamp_header=request.headers.get("X-Cerberus-Timestamp"),
+            max_skew_seconds=state["max_skew_seconds"],
+        )
+
+        try:
+            event: dict[str, Any] = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="malformed json body",
+            ) from exc
+
+        if not isinstance(event, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="event must be a JSON object",
+            )
+
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="missing event type",
+            )
+
+        handler = HANDLERS.get(event_type)
+        if handler is None:
+            logger.info("ignoring unhandled event type=%s id=%s", event_type, event.get("id"))
+            return {"status": "ignored"}
+
+        handler(event)
+        return {"status": "ok"}
+
+    return fastapi_app
+
+
+app = _build_app() if _FASTAPI_AVAILABLE else None
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _main() -> int:
+    if not _FASTAPI_AVAILABLE or app is None:
+        sys.stderr.write(
+            "fastapi is not installed. Install it with `pip install fastapi uvicorn` "
+            "to run the webhook receiver.\n"
+        )
+        return 1
+
+    try:
+        import uvicorn  # type: ignore[import-not-found]
+    except ImportError:
+        sys.stderr.write(
+            "uvicorn is not installed. Install it with `pip install uvicorn` "
+            "to run the webhook receiver.\n"
+        )
+        return 1
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())


### PR DESCRIPTION
Instance D scope per `docs/superpowers/plans/2026-04-22-overhaul-p4-sdks.md`.
Foundation from Instance A (SHA `e4fedb4`) untouched; no package source edits.

## Summary

- 3 runnable examples under `examples/` (CLI KYB, async portfolio monitor, FastAPI webhook receiver).
- 20-cell narrated Jupyter notebook under `examples/notebooks/`.
- Production `README.md` (overwriting the A skeleton) with install/quickstart/auth/retries/errors/async/pagination overview.
- 4 Mintlify-ready guides under `docs/` (`quickstart.md`, `auth.md`, `errors.md`, `pagination.md`) ready for the P7 dev portal.
- Extended `CHANGELOG.md` under `v0.1.0-rc1` with the DX deliverables and a "Known gaps (rc1 → GA)" section.

## Test plan

- [x] `pytest -q` → 171 passed, 99.78 % coverage (unchanged from foundation).
- [x] `ruff check .` → All checks passed (includes the notebook).
- [x] `ruff format --check .` → 21 files already formatted.
- [x] `mypy --strict cerberus_compliance/` → Success, no issues found in 7 source files.
- [x] All 3 example modules import cleanly (`python -c "import examples.kyb_quickstart, examples.monitor_portfolio, examples.webhook_handler"`).
- [x] Notebook validates via `nbformat.read(...)` and every code cell parses via `ast.parse`.
- [ ] Reviewer: rebase onto `main` once `feat/resources-1` / `feat/resources-2` merge and verify the `TODO(#P4-B-merge)` markers in examples + notebook are the surgical-refactor targets.

## Notes

- Examples intentionally use the low-level `client._request("GET", path, params=...)` surface because B/C resources are still in flight. Each such call has a `TODO(#P4-B-merge): switch to client.entities.<method> once feat/resources-1 lands.` marker for a trivial post-merge rewrite.
- `examples/webhook_handler.py` imports cleanly even without `fastapi` / `uvicorn` installed (optional-dep guard).
- `examples/kyb_quickstart.py` uses `rich` when available, plain formatted output otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)