### PR TITLE
feat: sanctions + registries + regulations resources

### DIFF
--- a/cerberus_compliance/client.py
+++ b/cerberus_compliance/client.py
@@ -42,6 +42,18 @@ from cerberus_compliance.resources.persons import (
     AsyncPersonsResource,
     PersonsResource,
 )
+from cerberus_compliance.resources.registries import (
+    AsyncRegistriesResource,
+    RegistriesResource,
+)
+from cerberus_compliance.resources.regulations import (
+    AsyncRegulationsResource,
+    RegulationsResource,
+)
+from cerberus_compliance.resources.sanctions import (
+    AsyncSanctionsResource,
+    SanctionsResource,
+)
 from cerberus_compliance.retry import RetryConfig, backoff_seconds, should_retry
 
 __all__ = [
@@ -93,6 +105,9 @@ class CerberusClient:
     base_url: str
     timeout: float
     retry: RetryConfig
+    sanctions: SanctionsResource
+    registries: RegistriesResource
+    regulations: RegulationsResource
 
     def __init__(
         self,
@@ -117,7 +132,10 @@ class CerberusClient:
         self.entities: EntitiesResource = EntitiesResource(self)
         self.persons: PersonsResource = PersonsResource(self)
         self.material_events: MaterialEventsResource = MaterialEventsResource(self)
-        # Sub-resources are wired below by Instances B/C — keep this exact marker:
+        self.sanctions: SanctionsResource = SanctionsResource(self)
+        self.registries: RegistriesResource = RegistriesResource(self)
+        self.regulations: RegulationsResource = RegulationsResource(self)
+        # Sub-resources are wired above by Instances B/C — keep this exact marker:
         # INSERT RESOURCES HERE
 
     def _request(
@@ -239,6 +257,9 @@ class AsyncCerberusClient:
     base_url: str
     timeout: float
     retry: RetryConfig
+    sanctions: AsyncSanctionsResource
+    registries: AsyncRegistriesResource
+    regulations: AsyncRegulationsResource
 
     def __init__(
         self,
@@ -263,7 +284,10 @@ class AsyncCerberusClient:
         self.entities: AsyncEntitiesResource = AsyncEntitiesResource(self)
         self.persons: AsyncPersonsResource = AsyncPersonsResource(self)
         self.material_events: AsyncMaterialEventsResource = AsyncMaterialEventsResource(self)
-        # Sub-resources are wired below by Instances B/C — keep this exact marker:
+        self.sanctions: AsyncSanctionsResource = AsyncSanctionsResource(self)
+        self.registries: AsyncRegistriesResource = AsyncRegistriesResource(self)
+        self.regulations: AsyncRegulationsResource = AsyncRegulationsResource(self)
+        # Sub-resources are wired above by Instances B/C — keep this exact marker:
         # INSERT RESOURCES HERE
 
     async def _request(

--- a/cerberus_compliance/resources/__init__.py
+++ b/cerberus_compliance/resources/__init__.py
@@ -1,4 +1,9 @@
-"""Public re-exports for the ``cerberus_compliance.resources`` package."""
+"""Public sub-resource exports for the Cerberus Compliance SDK.
+
+Instances B and C contribute resources append-only here. ``__all__`` and
+the import block stay alphabetically sorted so any future contributor
+rebases trivially regardless of merge order.
+"""
 
 from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
 from cerberus_compliance.resources.entities import (
@@ -13,14 +18,38 @@ from cerberus_compliance.resources.persons import (
     AsyncPersonsResource,
     PersonsResource,
 )
+from cerberus_compliance.resources.registries import (
+    AsyncRegistriesResource,
+    RegistriesResource,
+    RegistryType,
+)
+from cerberus_compliance.resources.regulations import (
+    AsyncRegulationsResource,
+    RegulationFramework,
+    RegulationsResource,
+)
+from cerberus_compliance.resources.sanctions import (
+    AsyncSanctionsResource,
+    SanctionSource,
+    SanctionsResource,
+)
 
 __all__ = [
     "AsyncBaseResource",
     "AsyncEntitiesResource",
     "AsyncMaterialEventsResource",
     "AsyncPersonsResource",
+    "AsyncRegistriesResource",
+    "AsyncRegulationsResource",
+    "AsyncSanctionsResource",
     "BaseResource",
     "EntitiesResource",
     "MaterialEventsResource",
     "PersonsResource",
+    "RegistriesResource",
+    "RegistryType",
+    "RegulationFramework",
+    "RegulationsResource",
+    "SanctionSource",
+    "SanctionsResource",
 ]

--- a/cerberus_compliance/resources/registries.py
+++ b/cerberus_compliance/resources/registries.py
@@ -1,0 +1,125 @@
+"""Public Chilean registries sub-resource (CMF / SII / DICOM / Conservador).
+
+Exposes list / get / iter_all endpoints plus a RUT-lookup helper that
+normalises the input (strips whitespace, dots, and hyphens; uppercases
+the check digit ``k``) before hitting the network. Invalid RUTs are
+rejected with :class:`ValueError` before any request is issued.
+
+The sub-resource follows the snake_case query-parameter convention
+(``registry_type=CMF``) to stay consistent with Python naming; the
+server accepts this form alongside the camelCase equivalent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Literal
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncRegistriesResource", "RegistriesResource", "RegistryType"]
+
+RegistryType = Literal["CMF", "SII", "DICOM", "Conservador"]
+
+
+def _normalize_rut(rut: str) -> str:
+    """Return the canonical ``<body>-<dv>`` form of ``rut``.
+
+    Strips whitespace, dots, and hyphens; uppercases the last character
+    (the check digit) when it is ``k``. Raises :class:`ValueError` when
+    the remaining string is empty or contains non-alphanumeric chars.
+    """
+    stripped = "".join(ch for ch in rut if not ch.isspace())
+    cleaned = stripped.replace(".", "").replace("-", "")
+
+    if not cleaned or not cleaned.isalnum():
+        raise ValueError(f"invalid RUT: {rut!r}")
+
+    canonical = cleaned.upper() if cleaned[-1] in {"k", "K"} else cleaned
+    return f"{canonical[:-1]}-{canonical[-1]}"
+
+
+def _build_list_params(
+    registry_type: RegistryType | None,
+    limit: int | None,
+) -> dict[str, Any] | None:
+    """Assemble a query dict, dropping ``None`` values.
+
+    Returns ``None`` when all parameters are absent so the client omits
+    the query string entirely.
+    """
+    params: dict[str, Any] = {}
+    if registry_type is not None:
+        params["registry_type"] = registry_type
+    if limit is not None:
+        params["limit"] = limit
+    return params or None
+
+
+def _drop_none(filters: dict[str, Any]) -> dict[str, Any] | None:
+    """Remove ``None``-valued entries; return ``None`` when nothing remains."""
+    cleaned = {k: v for k, v in filters.items() if v is not None}
+    return cleaned or None
+
+
+class RegistriesResource(BaseResource):
+    """Synchronous accessor for ``/registries`` endpoints."""
+
+    _path_prefix = "/registries"
+
+    def list(
+        self,
+        *,
+        registry_type: RegistryType | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List registries, optionally filtered by ``registry_type``."""
+        return self._list(params=_build_list_params(registry_type, limit))
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single registry entry by its server-assigned id."""
+        return self._get(id_)
+
+    def lookup_rut(self, rut: str) -> dict[str, Any]:
+        """Look up registries cross-referenced to a RUT.
+
+        The input is normalised in-process and rejected with
+        :class:`ValueError` when it cannot be interpreted as a RUT. On
+        success this issues ``GET /registries/lookup/rut/<body>-<dv>``.
+        """
+        normalized = _normalize_rut(rut)
+        path = f"{self._path_prefix}/lookup/rut/{normalized}"
+        return self._client._request("GET", path)
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Cursor-paginate through all registries matching ``filters``."""
+        return self._iter_all(params=_drop_none(filters))
+
+
+class AsyncRegistriesResource(AsyncBaseResource):
+    """Asynchronous accessor for ``/registries`` endpoints."""
+
+    _path_prefix = "/registries"
+
+    async def list(
+        self,
+        *,
+        registry_type: RegistryType | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List registries, optionally filtered by ``registry_type``."""
+        return await self._list(params=_build_list_params(registry_type, limit))
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single registry entry by its server-assigned id."""
+        return await self._get(id_)
+
+    async def lookup_rut(self, rut: str) -> dict[str, Any]:
+        """Async variant of :meth:`RegistriesResource.lookup_rut`."""
+        normalized = _normalize_rut(rut)
+        path = f"{self._path_prefix}/lookup/rut/{normalized}"
+        return await self._client._request("GET", path)
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Cursor-paginate through all registries matching ``filters``."""
+        return self._iter_all(params=_drop_none(filters))

--- a/cerberus_compliance/resources/registries.py
+++ b/cerberus_compliance/resources/registries.py
@@ -25,18 +25,24 @@ RegistryType = Literal["CMF", "SII", "DICOM", "Conservador"]
 def _normalize_rut(rut: str) -> str:
     """Return the canonical ``<body>-<dv>`` form of ``rut``.
 
-    Strips whitespace, dots, and hyphens; uppercases the last character
-    (the check digit) when it is ``k``. Raises :class:`ValueError` when
-    the remaining string is empty or contains non-alphanumeric chars.
+    The input is stripped of whitespace, dots, and hyphens; the check
+    digit is uppercased when it is ``k``. Raises :class:`ValueError`
+    when the string is empty, shorter than two characters, contains
+    non-alphanumeric chars, has a non-numeric body, or has a verifier
+    that is not a digit or ``K``. This validation is syntactic only:
+    the check-digit arithmetic is not verified.
     """
     stripped = "".join(ch for ch in rut if not ch.isspace())
     cleaned = stripped.replace(".", "").replace("-", "")
 
-    if not cleaned or not cleaned.isalnum():
+    if len(cleaned) < 2 or not cleaned.isalnum():
         raise ValueError(f"invalid RUT: {rut!r}")
 
-    canonical = cleaned.upper() if cleaned[-1] in {"k", "K"} else cleaned
-    return f"{canonical[:-1]}-{canonical[-1]}"
+    body, dv = cleaned[:-1], cleaned[-1].upper()
+    if not body.isdigit() or not (dv.isdigit() or dv == "K"):
+        raise ValueError(f"invalid RUT: {rut!r}")
+
+    return f"{body}-{dv}"
 
 
 def _build_list_params(

--- a/cerberus_compliance/resources/regulations.py
+++ b/cerberus_compliance/resources/regulations.py
@@ -1,0 +1,119 @@
+"""``/regulations`` sub-resource — regulatory-compliance applicability.
+
+A *regulation* record answers the question: *which normative framework
+(Chilean Ley 21.521 / Ley 21.719 / NCG 514, or international SOX / MiFID)
+applies to which entity, and with what status?* The API exposes two
+read-only endpoints — ``GET /regulations`` (list, filterable by
+``entity_id`` and ``framework``) and ``GET /regulations/<id>`` (detail).
+
+Both sync and async flavours of the resource delegate to the cursor-
+pagination helpers on :class:`~cerberus_compliance.resources._base.BaseResource`
+/ :class:`~cerberus_compliance.resources._base.AsyncBaseResource`.
+
+Example
+-------
+.. code-block:: python
+
+    from cerberus_compliance import CerberusClient
+
+    client = CerberusClient(api_key="ck_live_...")
+    regs = client.regulations.list(entity_id="ent_1", framework="Ley21521")
+
+    for rec in client.regulations.iter_all(framework="SOX"):
+        ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Literal
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = [
+    "AsyncRegulationsResource",
+    "RegulationFramework",
+    "RegulationsResource",
+]
+
+RegulationFramework = Literal["Ley21521", "Ley21719", "NCG514", "SOX", "MiFID"]
+"""Supported regulatory frameworks recognised by the Cerberus API."""
+
+
+def _build_params(**raw: Any) -> dict[str, Any] | None:
+    """Assemble a query-parameter dict, dropping any values that are ``None``.
+
+    Returns ``None`` when no parameters remain so the transport layer can
+    skip emitting an empty query string.
+    """
+    params = {key: value for key, value in raw.items() if value is not None}
+    return params or None
+
+
+class RegulationsResource(BaseResource):
+    """Sync accessor for the ``/regulations`` endpoint.
+
+    Exposes :meth:`list`, :meth:`get`, and :meth:`iter_all` over the
+    shared :class:`BaseResource` helpers.
+    """
+
+    _path_prefix = "/regulations"
+
+    def list(
+        self,
+        *,
+        entity_id: str | None = None,
+        framework: RegulationFramework | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return a single page of regulation records.
+
+        All filters are optional; ``None`` values are omitted from the
+        outgoing query string. The server decides the default page size
+        when ``limit`` is not supplied.
+        """
+        params = _build_params(entity_id=entity_id, framework=framework, limit=limit)
+        return self._list(params=params)
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single regulation record by its identifier."""
+        return self._get(id_)
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Cursor-paginate through every matching regulation record.
+
+        Accepts the same filters as :meth:`list` (``entity_id``,
+        ``framework``, ``limit``) via keyword arguments, plus any
+        forward-compatible server-side filters the caller wishes to
+        pass through. ``None`` values are stripped; the server's
+        cursor is forwarded automatically on each subsequent page.
+        """
+        return self._iter_all(params=_build_params(**filters))
+
+
+class AsyncRegulationsResource(AsyncBaseResource):
+    """Async mirror of :class:`RegulationsResource`."""
+
+    _path_prefix = "/regulations"
+
+    async def list(
+        self,
+        *,
+        entity_id: str | None = None,
+        framework: RegulationFramework | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async variant of :meth:`RegulationsResource.list`."""
+        params = _build_params(entity_id=entity_id, framework=framework, limit=limit)
+        return await self._list(params=params)
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`RegulationsResource.get`."""
+        return await self._get(id_)
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async variant of :meth:`RegulationsResource.iter_all`.
+
+        Returns an :class:`AsyncIterator`; consume with ``async for``.
+        """
+        return self._iter_all(params=_build_params(**filters))

--- a/cerberus_compliance/resources/sanctions.py
+++ b/cerberus_compliance/resources/sanctions.py
@@ -1,0 +1,126 @@
+"""Sanctions sub-resource.
+
+Lists and retrieves sanction hits against an entity or natural person.
+Supported issuing authorities (``source``) include OFAC, UN, EU, and the
+Chilean CMF. ``ONU`` is accepted as a Spanish-locale alias for ``UN`` and
+is normalised on the wire so the server only ever sees canonical values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Literal
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncSanctionsResource", "SanctionSource", "SanctionsResource"]
+
+SanctionSource = Literal["OFAC", "EU", "UN", "ONU", "CMF"]
+
+
+def _build_params(
+    *,
+    target_id: str | None,
+    source: SanctionSource | None,
+    active: bool | None,
+    limit: int | None,
+) -> dict[str, Any]:
+    """Assemble the query-string dict, dropping ``None`` values.
+
+    Also normalises the ``ONU`` locale alias to the canonical ``UN`` so
+    the backend receives a single stable value regardless of caller
+    preference.
+    """
+    params: dict[str, Any] = {}
+    if target_id is not None:
+        params["target_id"] = target_id
+    if source is not None:
+        params["source"] = "UN" if source == "ONU" else source
+    if active is not None:
+        params["active"] = active
+    if limit is not None:
+        params["limit"] = limit
+    return params
+
+
+def _normalise_filters(filters: dict[str, Any]) -> dict[str, Any]:
+    """Apply the ``ONU`` -> ``UN`` alias to raw ``**filters`` kwargs."""
+    normalised = dict(filters)
+    if normalised.get("source") == "ONU":
+        normalised["source"] = "UN"
+    return normalised
+
+
+class SanctionsResource(BaseResource):
+    """Synchronous accessor for ``/sanctions``.
+
+    Filters are passed as query parameters; ``None`` values are omitted.
+    The ``source`` filter accepts ``"ONU"`` as a locale alias and
+    normalises it to ``"UN"`` before the request is sent.
+    """
+
+    _path_prefix = "/sanctions"
+
+    def list(
+        self,
+        *,
+        target_id: str | None = None,
+        source: SanctionSource | None = None,
+        active: bool | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List sanction hits matching the supplied filters.
+
+        Returns the ``data`` array from the API envelope. Any ``None``
+        filter is dropped so the wire URL stays minimal.
+        """
+        params = _build_params(target_id=target_id, source=source, active=active, limit=limit)
+        return self._list(params=params or None)
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single sanction record by its identifier."""
+        return self._get(id_)
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Iterate every matching sanction across all pages.
+
+        Applies the same ``ONU`` -> ``UN`` normalisation as :meth:`list`
+        so every paged request carries the canonical source value.
+        """
+        params = _normalise_filters(filters)
+        return self._iter_all(params=params or None)
+
+
+class AsyncSanctionsResource(AsyncBaseResource):
+    """Asynchronous accessor for ``/sanctions``.
+
+    Mirrors :class:`SanctionsResource`; :meth:`iter_all` returns an
+    :class:`~collections.abc.AsyncIterator` rather than a coroutine.
+    """
+
+    _path_prefix = "/sanctions"
+
+    async def list(
+        self,
+        *,
+        target_id: str | None = None,
+        source: SanctionSource | None = None,
+        active: bool | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async variant of :meth:`SanctionsResource.list`."""
+        params = _build_params(target_id=target_id, source=source, active=active, limit=limit)
+        return await self._list(params=params or None)
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`SanctionsResource.get`."""
+        return await self._get(id_)
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async variant of :meth:`SanctionsResource.iter_all`.
+
+        Returns an async iterator directly (not a coroutine) so it can
+        be consumed with ``async for`` without an extra ``await``.
+        """
+        params = _normalise_filters(filters)
+        return self._iter_all(params=params or None)

--- a/cerberus_compliance/resources/sanctions.py
+++ b/cerberus_compliance/resources/sanctions.py
@@ -44,8 +44,13 @@ def _build_params(
 
 
 def _normalise_filters(filters: dict[str, Any]) -> dict[str, Any]:
-    """Apply the ``ONU`` -> ``UN`` alias to raw ``**filters`` kwargs."""
-    normalised = dict(filters)
+    """Drop ``None``-valued kwargs and apply the ``ONU`` -> ``UN`` alias.
+
+    The ``None`` filter is always stripped so callers can pass optional
+    kwargs through ``**filters`` without polluting the wire URL with
+    ``?source=`` and similar empty values.
+    """
+    normalised = {k: v for k, v in filters.items() if v is not None}
     if normalised.get("source") == "ONU":
         normalised["source"] = "UN"
     return normalised

--- a/tests/resources/test_registries.py
+++ b/tests/resources/test_registries.py
@@ -1,0 +1,458 @@
+"""TDD tests for ``cerberus_compliance.resources.registries``.
+
+The :class:`RegistriesResource` proxies the public Chilean registries
+sub-API (CMF / SII / DICOM / Conservador de Bienes Raíces) plus a
+RUT-lookup helper that normalises the input before issuing the request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.registries import (
+    AsyncRegistriesResource,
+    RegistriesResource,
+)
+
+# ---------------------------------------------------------------------------
+# Meta / subclass hygiene
+# ---------------------------------------------------------------------------
+
+
+class TestRegistriesClassMeta:
+    def test_path_prefix_is_registries(self) -> None:
+        assert RegistriesResource._path_prefix == "/registries"
+        assert AsyncRegistriesResource._path_prefix == "/registries"
+
+    def test_is_subclass_of_base_resource(self) -> None:
+        assert issubclass(RegistriesResource, BaseResource)
+        assert issubclass(AsyncRegistriesResource, AsyncBaseResource)
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistriesResource:
+    def test_list_no_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "reg_1", "type": "CMF"}, {"id": "reg_2", "type": "SII"}],
+                    "next": None,
+                },
+            )
+        )
+        resource = RegistriesResource(sync_client)
+
+        items = resource.list()
+
+        assert items == [{"id": "reg_1", "type": "CMF"}, {"id": "reg_2", "type": "SII"}]
+        assert route.called
+        # No query string should have been sent.
+        assert route.calls.last.request.url.query == b""
+
+    def test_list_filters_registry_type(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "CMF"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "reg_1"}], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        items = resource.list(registry_type="CMF")
+
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    def test_list_forwards_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "DICOM", "limit": "5"}).mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        assert resource.list(registry_type="DICOM", limit=5) == []
+        assert route.called
+
+    def test_list_omits_none(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "SII"}).mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        # Passing only registry_type; limit defaults to None and must NOT be sent.
+        resource.list(registry_type="SII")
+
+        assert route.called
+        query = route.calls.last.request.url.query.decode()
+        assert "limit" not in query
+        assert "registry_type=SII" in query
+
+    def test_list_with_all_none_sends_no_query(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries").mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        resource.list(registry_type=None, limit=None)
+
+        assert route.called
+        assert route.calls.last.request.url.query == b""
+
+    def test_get_by_id(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get("/registries/reg_42").mock(
+            return_value=httpx.Response(
+                200, json={"id": "reg_42", "type": "Conservador", "status": "active"}
+            )
+        )
+        resource = RegistriesResource(sync_client)
+
+        result = resource.get("reg_42")
+
+        assert result == {"id": "reg_42", "type": "Conservador", "status": "active"}
+
+    def test_get_404_raises_cerberus_api_error(
+        self,
+        sync_client: CerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/registries/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json=problem_json(
+                    status=404, title="Not Found", detail="registry missing not found"
+                ),
+                headers={"content-type": "application/problem+json"},
+            )
+        )
+        resource = RegistriesResource(sync_client)
+
+        with pytest.raises(CerberusAPIError) as excinfo:
+            resource.get("missing")
+
+        assert excinfo.value.status == 404
+
+    def test_lookup_rut_normalizes_dots_hyphens(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-5").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-5", "name": "Acme"})
+        )
+        resource = RegistriesResource(sync_client)
+
+        result = resource.lookup_rut("12.345.678-5")
+
+        assert result == {"rut": "12345678-5", "name": "Acme"}
+        assert route.called
+
+    def test_lookup_rut_uppercases_k(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-K").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-K"})
+        )
+        resource = RegistriesResource(sync_client)
+
+        result = resource.lookup_rut("12.345.678-k")
+
+        assert result == {"rut": "12345678-K"}
+        assert route.called
+
+    def test_lookup_rut_strips_whitespace(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-5").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-5"})
+        )
+        resource = RegistriesResource(sync_client)
+
+        resource.lookup_rut(" 12345678-5 ")
+
+        assert route.called
+
+    def test_lookup_rut_already_canonical(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/76543210-9").mock(
+            return_value=httpx.Response(200, json={"rut": "76543210-9"})
+        )
+        resource = RegistriesResource(sync_client)
+
+        assert resource.lookup_rut("76543210-9") == {"rut": "76543210-9"}
+        assert route.called
+
+    def test_lookup_rut_invalid_empty_raises_value_error(self, sync_client: CerberusClient) -> None:
+        resource = RegistriesResource(sync_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("")
+
+    def test_lookup_rut_invalid_whitespace_only_raises(self, sync_client: CerberusClient) -> None:
+        resource = RegistriesResource(sync_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("   ")
+
+    def test_lookup_rut_invalid_non_alnum_raises(self, sync_client: CerberusClient) -> None:
+        resource = RegistriesResource(sync_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("abc!@#")
+
+    def test_lookup_rut_invalid_only_punctuation_raises(self, sync_client: CerberusClient) -> None:
+        resource = RegistriesResource(sync_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("...---")
+
+    def test_iter_all_paginates_forwards_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Specific (cursor) route FIRST — respx is subset-match and picks in order.
+        page2 = respx_mock.get(
+            "/registries", params={"registry_type": "SII", "cursor": "tok2"}
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "reg_2"}], "next": None}))
+        page1 = respx_mock.get("/registries", params={"registry_type": "SII"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "reg_1"}], "next": "tok2"})
+        )
+        resource = RegistriesResource(sync_client)
+
+        items = list(resource.iter_all(registry_type="SII"))
+
+        assert items == [{"id": "reg_1"}, {"id": "reg_2"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_drops_none_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "CMF"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "r1"}], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        items = list(resource.iter_all(registry_type="CMF", limit=None))
+
+        assert items == [{"id": "r1"}]
+        assert route.called
+        query = route.calls.last.request.url.query.decode()
+        assert "limit" not in query
+
+    def test_iter_all_stops_on_null_next(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "only"}], "next": None})
+        )
+        resource = RegistriesResource(sync_client)
+
+        assert list(resource.iter_all()) == [{"id": "only"}]
+        assert route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRegistriesResource:
+    async def test_list_no_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "reg_a"}, {"id": "reg_b"}], "next": None}
+            )
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        items = await resource.list()
+
+        assert items == [{"id": "reg_a"}, {"id": "reg_b"}]
+        assert route.called
+        assert route.calls.last.request.url.query == b""
+
+    async def test_list_filters_registry_type(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "DICOM"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "d1"}], "next": None})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        items = await resource.list(registry_type="DICOM")
+
+        assert items == [{"id": "d1"}]
+        assert route.called
+
+    async def test_list_omits_none(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "SII"}).mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        await resource.list(registry_type="SII")
+
+        assert route.called
+        query = route.calls.last.request.url.query.decode()
+        assert "limit" not in query
+        assert "registry_type=SII" in query
+
+    async def test_list_with_limit(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"limit": "3"}).mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        assert await resource.list(limit=3) == []
+        assert route.called
+
+    async def test_get_by_id(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/registries/reg_z").mock(
+            return_value=httpx.Response(200, json={"id": "reg_z", "type": "CMF"})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        assert await resource.get("reg_z") == {"id": "reg_z", "type": "CMF"}
+
+    async def test_get_404_raises_cerberus_api_error(
+        self,
+        async_client: AsyncCerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/registries/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json=problem_json(status=404, title="Not Found"),
+                headers={"content-type": "application/problem+json"},
+            )
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        with pytest.raises(CerberusAPIError) as excinfo:
+            await resource.get("missing")
+
+        assert excinfo.value.status == 404
+
+    async def test_lookup_rut_normalizes_dots_hyphens(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-5").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-5"})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        assert await resource.lookup_rut("12.345.678-5") == {"rut": "12345678-5"}
+        assert route.called
+
+    async def test_lookup_rut_uppercases_k(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-K").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-K"})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        assert await resource.lookup_rut("12.345.678-k") == {"rut": "12345678-K"}
+        assert route.called
+
+    async def test_lookup_rut_strips_whitespace(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries/lookup/rut/12345678-5").mock(
+            return_value=httpx.Response(200, json={"rut": "12345678-5"})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        await resource.lookup_rut(" 12345678-5 ")
+
+        assert route.called
+
+    async def test_lookup_rut_invalid_empty_raises(self, async_client: AsyncCerberusClient) -> None:
+        resource = AsyncRegistriesResource(async_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            await resource.lookup_rut("")
+
+    async def test_lookup_rut_invalid_non_alnum_raises(
+        self, async_client: AsyncCerberusClient
+    ) -> None:
+        resource = AsyncRegistriesResource(async_client)
+
+        with pytest.raises(ValueError, match="invalid RUT"):
+            await resource.lookup_rut("abc!@#")
+
+    async def test_iter_all_paginates_forwards_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Specific route first.
+        respx_mock.get("/registries", params={"registry_type": "Conservador", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "c2"}], "next": None})
+        )
+        respx_mock.get("/registries", params={"registry_type": "Conservador"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "c1"}], "next": "n2"})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(registry_type="Conservador"):
+            collected.append(item)
+
+        assert collected == [{"id": "c1"}, {"id": "c2"}]
+
+    async def test_iter_all_drops_none_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries", params={"registry_type": "CMF"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "r1"}], "next": None})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(registry_type="CMF", limit=None):
+            collected.append(item)
+
+        assert collected == [{"id": "r1"}]
+        assert route.called
+        query = route.calls.last.request.url.query.decode()
+        assert "limit" not in query
+
+    async def test_iter_all_stops_on_null_next(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/registries").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "x"}], "next": None})
+        )
+        resource = AsyncRegistriesResource(async_client)
+
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            collected.append(item)
+
+        assert collected == [{"id": "x"}]
+        assert route.call_count == 1

--- a/tests/resources/test_registries.py
+++ b/tests/resources/test_registries.py
@@ -223,6 +223,28 @@ class TestRegistriesResource:
         with pytest.raises(ValueError, match="invalid RUT"):
             resource.lookup_rut("...---")
 
+    @pytest.mark.parametrize("bad", ["5", "k", "K", "-5", "5-"])
+    def test_lookup_rut_single_char_body_rejected(
+        self, sync_client: CerberusClient, bad: str
+    ) -> None:
+        # After stripping, a single alphanumeric character leaves an
+        # empty body — reject before emitting a malformed ``-5`` path.
+        resource = RegistriesResource(sync_client)
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut(bad)
+
+    def test_lookup_rut_alphabetic_body_rejected(self, sync_client: CerberusClient) -> None:
+        # Body must be purely numeric (Chilean RUT convention).
+        resource = RegistriesResource(sync_client)
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("abc1234-5")
+
+    def test_lookup_rut_non_dk_verifier_rejected(self, sync_client: CerberusClient) -> None:
+        # Verifier must be a digit or ``K``; anything else is syntactically invalid.
+        resource = RegistriesResource(sync_client)
+        with pytest.raises(ValueError, match="invalid RUT"):
+            resource.lookup_rut("12345678-Z")
+
     def test_iter_all_paginates_forwards_filters(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:

--- a/tests/resources/test_regulations.py
+++ b/tests/resources/test_regulations.py
@@ -1,0 +1,440 @@
+"""TDD tests for ``cerberus_compliance.resources.regulations``.
+
+The ``regulations`` resource lists and fetches regulatory-compliance
+applicability records — which laws/norms bind which entity under which
+framework (Chilean Ley 21.521, Ley 21.719, NCG 514, plus international
+SOX / MiFID). It is a thin, strictly-typed adapter over the shared
+``BaseResource`` / ``AsyncBaseResource`` helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.regulations import (
+    AsyncRegulationsResource,
+    RegulationsResource,
+)
+
+# ---------------------------------------------------------------------------
+# Meta / typing sanity
+# ---------------------------------------------------------------------------
+
+
+class TestRegulationsResourceMeta:
+    def test_sync_path_prefix(self) -> None:
+        assert RegulationsResource._path_prefix == "/regulations"
+
+    def test_async_path_prefix(self) -> None:
+        assert AsyncRegulationsResource._path_prefix == "/regulations"
+
+    def test_sync_subclass_of_base(self) -> None:
+        assert issubclass(RegulationsResource, BaseResource)
+
+    def test_async_subclass_of_base(self) -> None:
+        assert issubclass(AsyncRegulationsResource, AsyncBaseResource)
+
+    def test_sync_constructor_binds_client(self, sync_client: CerberusClient) -> None:
+        resource = RegulationsResource(sync_client)
+        assert resource._client is sync_client
+
+    def test_async_constructor_binds_client(self, async_client: AsyncCerberusClient) -> None:
+        resource = AsyncRegulationsResource(async_client)
+        assert resource._client is async_client
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegulationsResource:
+    def test_list_no_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "reg_1", "framework": "Ley21521"},
+                        {"id": "reg_2", "framework": "NCG514"},
+                    ],
+                    "next": None,
+                    "page": {},
+                },
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list()
+        assert items == [
+            {"id": "reg_1", "framework": "Ley21521"},
+            {"id": "reg_2", "framework": "NCG514"},
+        ]
+        assert route.called
+        assert route.calls.last.request.url.params.get("entity_id") is None
+        assert route.calls.last.request.url.params.get("framework") is None
+
+    def test_list_filters_entity_id(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"entity_id": "ent_1"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list(entity_id="ent_1")
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    def test_list_filters_framework(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"framework": "Ley21521"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1", "framework": "Ley21521"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list(framework="Ley21521")
+        assert items == [{"id": "reg_1", "framework": "Ley21521"}]
+        assert route.called
+
+    def test_list_filters_both(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/regulations",
+            params={"entity_id": "ent_1", "framework": "Ley21719"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_3"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list(entity_id="ent_1", framework="Ley21719")
+        assert items == [{"id": "reg_3"}]
+        assert route.called
+
+    def test_list_omits_none(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"framework": "NCG514"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_9"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list(framework="NCG514")
+        assert items == [{"id": "reg_9"}]
+        # Explicitly verify that `entity_id` was NOT sent when None.
+        sent_url = route.calls.last.request.url
+        assert "entity_id" not in sent_url.params
+        assert "limit" not in sent_url.params
+        assert sent_url.params.get("framework") == "NCG514"
+
+    def test_list_forwards_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"limit": "50"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        items = resource.list(limit=50)
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    def test_get_by_id(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        body = {
+            "id": "reg_42",
+            "entity_id": "ent_1",
+            "framework": "SOX",
+            "status": "applicable",
+        }
+        respx_mock.get("/regulations/reg_42").mock(return_value=httpx.Response(200, json=body))
+        resource = RegulationsResource(sync_client)
+        assert resource.get("reg_42") == body
+
+    def test_get_404_raises_cerberus_api_error(
+        self,
+        sync_client: CerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/regulations/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json=problem_json(
+                    status=404,
+                    title="Not Found",
+                    detail="Regulation 'missing' not found",
+                ),
+                headers={"Content-Type": "application/problem+json"},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        with pytest.raises(CerberusAPIError) as excinfo:
+            resource.get("missing")
+        assert excinfo.value.status == 404
+
+    def test_iter_all_two_pages_forwards_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Register the cursor-specific route FIRST so respx matches it
+        # before the more generic "framework only" route (subset-match).
+        page2 = respx_mock.get(
+            "/regulations",
+            params={"framework": "SOX", "cursor": "cur2"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_b"}], "next": None},
+            )
+        )
+        page1 = respx_mock.get(
+            "/regulations",
+            params={"framework": "SOX"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_a"}], "next": "cur2"},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        out = list(resource.iter_all(framework="SOX"))
+        assert out == [{"id": "reg_a"}, {"id": "reg_b"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_stops_on_null_next(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_only"}], "next": None},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        assert list(resource.iter_all()) == [{"id": "reg_only"}]
+        assert route.call_count == 1
+
+    def test_iter_all_stops_on_missing_next_key(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_only"}]},
+            )
+        )
+        resource = RegulationsResource(sync_client)
+        assert list(resource.iter_all()) == [{"id": "reg_only"}]
+        assert route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRegulationsResource:
+    async def test_list_no_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "reg_1"},
+                        {"id": "reg_2"},
+                    ],
+                    "next": None,
+                },
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list()
+        assert items == [{"id": "reg_1"}, {"id": "reg_2"}]
+        assert route.called
+
+    async def test_list_filters_entity_id(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"entity_id": "ent_1"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list(entity_id="ent_1")
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    async def test_list_filters_framework(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"framework": "Ley21521"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list(framework="Ley21521")
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    async def test_list_filters_both(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/regulations",
+            params={"entity_id": "ent_1", "framework": "Ley21719"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_3"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list(entity_id="ent_1", framework="Ley21719")
+        assert items == [{"id": "reg_3"}]
+        assert route.called
+
+    async def test_list_omits_none(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"framework": "NCG514"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_9"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list(framework="NCG514")
+        assert items == [{"id": "reg_9"}]
+        sent_url = route.calls.last.request.url
+        assert "entity_id" not in sent_url.params
+        assert "limit" not in sent_url.params
+
+    async def test_list_forwards_limit(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations", params={"limit": "25"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_1"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        items = await resource.list(limit=25)
+        assert items == [{"id": "reg_1"}]
+        assert route.called
+
+    async def test_get_by_id(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        body = {"id": "reg_42", "framework": "MiFID"}
+        respx_mock.get("/regulations/reg_42").mock(return_value=httpx.Response(200, json=body))
+        resource = AsyncRegulationsResource(async_client)
+        assert await resource.get("reg_42") == body
+
+    async def test_get_404_raises_cerberus_api_error(
+        self,
+        async_client: AsyncCerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/regulations/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json=problem_json(
+                    status=404,
+                    title="Not Found",
+                    detail="Regulation 'missing' not found",
+                ),
+                headers={"Content-Type": "application/problem+json"},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        with pytest.raises(CerberusAPIError) as excinfo:
+            await resource.get("missing")
+        assert excinfo.value.status == 404
+
+    async def test_iter_all_two_pages_forwards_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Cursor-specific route FIRST (see sync sibling for rationale).
+        respx_mock.get(
+            "/regulations",
+            params={"framework": "SOX", "cursor": "cur2"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_b"}], "next": None},
+            )
+        )
+        respx_mock.get(
+            "/regulations",
+            params={"framework": "SOX"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_a"}], "next": "cur2"},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all(framework="SOX"):
+            out.append(item)
+        assert out == [{"id": "reg_a"}, {"id": "reg_b"}]
+
+    async def test_iter_all_stops_on_null_next(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_only"}], "next": None},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            out.append(item)
+        assert out == [{"id": "reg_only"}]
+        assert route.call_count == 1
+
+    async def test_iter_all_stops_on_missing_next_key(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "reg_only"}]},
+            )
+        )
+        resource = AsyncRegulationsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            out.append(item)
+        assert out == [{"id": "reg_only"}]
+        assert route.call_count == 1

--- a/tests/resources/test_sanctions.py
+++ b/tests/resources/test_sanctions.py
@@ -226,6 +226,17 @@ class TestSanctionsResource:
         assert page1.called
         assert page2.called
 
+    def test_iter_all_drops_none_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # `None`-valued kwargs must not bleed into the wire URL.
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "z"}], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        assert list(resource.iter_all(source=None, target_id=None, active=None)) == [{"id": "z"}]
+        assert route.calls.last.request.url.query == b""
+
 
 # ---------------------------------------------------------------------------
 # Async behaviour
@@ -378,3 +389,16 @@ class TestAsyncSanctionsResource:
             out.append(item)
         assert out == [{"id": "x"}]
         assert route.called
+
+    async def test_iter_all_drops_none_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "z"}], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all(source=None, target_id=None, active=None):
+            out.append(item)
+        assert out == [{"id": "z"}]
+        assert route.calls.last.request.url.query == b""

--- a/tests/resources/test_sanctions.py
+++ b/tests/resources/test_sanctions.py
@@ -1,0 +1,380 @@
+"""TDD tests for ``cerberus_compliance.resources.sanctions``.
+
+Covers the public ``SanctionsResource`` / ``AsyncSanctionsResource``
+surface: filter forwarding, the ``ONU`` -> ``UN`` alias normalisation,
+single-item fetch, 404 error mapping, 429 retry, and cursor pagination
+(sync + async).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.sanctions import (
+    AsyncSanctionsResource,
+    SanctionsResource,
+)
+
+# ---------------------------------------------------------------------------
+# Static structural tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_path_prefix_is_sanctions() -> None:
+    assert SanctionsResource._path_prefix == "/sanctions"
+
+
+def test_async_path_prefix_is_sanctions() -> None:
+    assert AsyncSanctionsResource._path_prefix == "/sanctions"
+
+
+def test_sync_inherits_base_resource() -> None:
+    assert issubclass(SanctionsResource, BaseResource)
+
+
+def test_async_inherits_async_base_resource() -> None:
+    assert issubclass(AsyncSanctionsResource, AsyncBaseResource)
+
+
+# ---------------------------------------------------------------------------
+# Sync behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSanctionsResource:
+    def test_list_no_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "s1"}, {"id": "s2"}], "next": None},
+            )
+        )
+        resource = SanctionsResource(sync_client)
+        assert resource.list() == [{"id": "s1"}, {"id": "s2"}]
+        assert route.called
+        # No query parameters were appended.
+        assert route.calls.last.request.url.query == b""
+
+    def test_list_with_target_id(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions", params={"target_id": "ent_42"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "s1"}], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        assert resource.list(target_id="ent_42") == [{"id": "s1"}]
+        assert route.called
+
+    def test_list_with_source_and_active(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # httpx serialises `True` -> "true" via the str() codec it uses for
+        # query params. Assert by inspecting the actual query string rather
+        # than relying on respx subset-matching for booleans.
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "s9"}], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        out = resource.list(source="OFAC", active=True)
+        assert out == [{"id": "s9"}]
+        assert route.called
+
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params.get("source") == "OFAC"
+        # Accept either literal case that httpx might emit.
+        assert params.get("active") in {"true", "True"}
+        assert "target_id" not in params
+
+    def test_list_onu_alias_translates_to_un(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Policy: normalise the locale alias "ONU" to the canonical "UN"
+        # before the request leaves the SDK.
+        route = respx_mock.get("/sanctions", params={"source": "UN"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "u1"}], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        out = resource.list(source="ONU")
+        assert out == [{"id": "u1"}]
+        assert route.called
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["source"] == "UN"
+
+    def test_list_omits_none_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        resource.list(source="OFAC")
+        assert route.called
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params == {"source": "OFAC"}
+        assert "target_id" not in params
+        assert "active" not in params
+        assert "limit" not in params
+
+    def test_list_with_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions", params={"limit": "50"}).mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        resource.list(limit=50)
+        assert route.called
+
+    def test_list_active_false_forwarded(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = SanctionsResource(sync_client)
+        resource.list(active=False)
+        assert route.called
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params.get("active") in {"false", "False"}
+
+    def test_get_by_id(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get("/sanctions/sanc_123").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "sanc_123", "source": "OFAC", "active": True},
+            )
+        )
+        resource = SanctionsResource(sync_client)
+        assert resource.get("sanc_123") == {
+            "id": "sanc_123",
+            "source": "OFAC",
+            "active": True,
+        }
+
+    def test_get_404_raises(
+        self,
+        sync_client: CerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/sanctions/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json=problem_json(status=404, title="Not Found"),
+            )
+        )
+        resource = SanctionsResource(sync_client)
+        with pytest.raises(CerberusAPIError) as exc:
+            resource.get("missing")
+        assert exc.value.status == 404
+
+    def test_get_429_retries_then_returns(
+        self,
+        sync_client: CerberusClient,
+        respx_mock: respx.MockRouter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Avoid real sleeping while still exercising the retry branch.
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        respx_mock.get("/sanctions/sanc_1").mock(
+            side_effect=[
+                httpx.Response(429, headers={"Retry-After": "0"}),
+                httpx.Response(200, json={"id": "sanc_1"}),
+            ]
+        )
+        resource = SanctionsResource(sync_client)
+        assert resource.get("sanc_1") == {"id": "sanc_1"}
+
+    def test_iter_all_two_pages(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Specific (cursor) route registered FIRST so respx dispatches it
+        # before the catch-all for page 1.
+        page2 = respx_mock.get("/sanctions", params={"cursor": "p2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
+        )
+        page1 = respx_mock.get("/sanctions", params={}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "p2"})
+        )
+        resource = SanctionsResource(sync_client)
+        out = list(resource.iter_all())
+        assert out == [{"id": "a"}, {"id": "b"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_forwards_filters_each_page(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page2 = respx_mock.get("/sanctions", params={"active": "true", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
+        )
+        page1 = respx_mock.get("/sanctions", params={"active": "true"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
+        )
+        resource = SanctionsResource(sync_client)
+        out = list(resource.iter_all(active=True))
+        assert out == [{"id": "a"}, {"id": "b"}]
+        assert page1.called
+        assert page2.called
+
+
+# ---------------------------------------------------------------------------
+# Async behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSanctionsResource:
+    async def test_list_no_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "s1"}], "next": None},
+            )
+        )
+        resource = AsyncSanctionsResource(async_client)
+        assert await resource.list() == [{"id": "s1"}]
+        assert route.calls.last.request.url.query == b""
+
+    async def test_list_with_target_id(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions", params={"target_id": "per_7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "x"}], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        assert await resource.list(target_id="per_7") == [{"id": "x"}]
+        assert route.called
+
+    async def test_list_with_source_and_active(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        await resource.list(source="EU", active=True)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params.get("source") == "EU"
+        assert params.get("active") in {"true", "True"}
+
+    async def test_list_onu_alias_translates_to_un(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions", params={"source": "UN"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "u1"}], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        out = await resource.list(source="ONU")
+        assert out == [{"id": "u1"}]
+        assert route.called
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["source"] == "UN"
+
+    async def test_list_omits_none_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        await resource.list(source="CMF")
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params == {"source": "CMF"}
+
+    async def test_get_by_id(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/sanctions/s_99").mock(
+            return_value=httpx.Response(200, json={"id": "s_99"})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        assert await resource.get("s_99") == {"id": "s_99"}
+
+    async def test_get_404_raises(
+        self,
+        async_client: AsyncCerberusClient,
+        respx_mock: respx.MockRouter,
+        problem_json: Any,
+    ) -> None:
+        respx_mock.get("/sanctions/ghost").mock(
+            return_value=httpx.Response(404, json=problem_json(status=404, title="Not Found"))
+        )
+        resource = AsyncSanctionsResource(async_client)
+        with pytest.raises(CerberusAPIError) as exc:
+            await resource.get("ghost")
+        assert exc.value.status == 404
+
+    async def test_get_429_retries_then_returns(
+        self,
+        async_client: AsyncCerberusClient,
+        respx_mock: respx.MockRouter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def fake_sleep(_s: float) -> None:
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        respx_mock.get("/sanctions/rl").mock(
+            side_effect=[
+                httpx.Response(429, headers={"Retry-After": "0"}),
+                httpx.Response(200, json={"id": "rl"}),
+            ]
+        )
+        resource = AsyncSanctionsResource(async_client)
+        assert await resource.get("rl") == {"id": "rl"}
+
+    async def test_iter_all_two_pages(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/sanctions", params={"cursor": "p2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
+        )
+        respx_mock.get("/sanctions", params={}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "p2"})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            out.append(item)
+        assert out == [{"id": "a"}, {"id": "b"}]
+
+    async def test_iter_all_forwards_filters_each_page(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/sanctions", params={"active": "true", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
+        )
+        respx_mock.get("/sanctions", params={"active": "true"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all(active=True):
+            out.append(item)
+        assert out == [{"id": "a"}, {"id": "b"}]
+
+    async def test_iter_all_onu_alias_normalises(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Normalisation is applied consistently by both ``list`` and
+        # ``iter_all``, so the server always sees the canonical ``UN``.
+        route = respx_mock.get("/sanctions", params={"source": "UN"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "x"}], "next": None})
+        )
+        resource = AsyncSanctionsResource(async_client)
+        out: list[dict[str, Any]] = []
+        async for item in resource.iter_all(source="ONU"):
+            out.append(item)
+        assert out == [{"id": "x"}]
+        assert route.called


### PR DESCRIPTION
## Summary

Implements Instance C scope from [`docs/superpowers/plans/2026-04-22-overhaul-p4-sdks.md`](https://github.com/l0rdbarcsacs/cerberus_compliance/blob/main/docs/superpowers/plans/2026-04-22-overhaul-p4-sdks.md) in parallel with Instances B and D on top of the A foundation (SHA `e4fedb46`).

Three sub-resources with sync + async flavours, each extending the foundation's `BaseResource` / `AsyncBaseResource` and covered by TDD-first `respx` tests.

- **`sanctions`** — `list(target_id, source, active, limit)`, `get(id_)`, `iter_all(**filters)`. `SanctionSource = Literal["OFAC", "EU", "UN", "ONU", "CMF"]`; the `ONU` locale alias is normalised to `UN` on the wire in both `list` and `iter_all` so the backend only ever sees canonical values.
- **`registries`** — `list(registry_type, limit)`, `get(id_)`, `lookup_rut(rut)`, `iter_all(**filters)`. `RegistryType = Literal["CMF", "SII", "DICOM", "Conservador"]`. `lookup_rut` normalises dots/hyphens/case and rejects syntactically-invalid input (`len < 2`, non-numeric body, verifier that isn't digit or `K`) with `ValueError` **before** any network call.
- **`regulations`** — `list(entity_id, framework, limit)`, `get(id_)`, `iter_all(**filters)`. `RegulationFramework = Literal["Ley21521", "Ley21719", "NCG514", "SOX", "MiFID"]`.

## Wire-up (append-only)

- `resources/__init__.py`: imports + `__all__` (alphabetically sorted so B's block rebases trivially).
- `client.py`: class-level attribute annotations + instantiation **above** the `# INSERT RESOURCES HERE` marker in both `CerberusClient.__init__` and `AsyncCerberusClient.__init__`. Marker left in place for Instance B.

## Audit trail

`cerberus-auditor` flagged two defects on the first commit; both fixed in a follow-up commit with regression tests:
1. `sanctions._normalise_filters` was forwarding `None`-valued `**filters` kwargs to the wire.
2. `registries._normalize_rut` accepted single-character inputs (producing malformed `-5` paths) and other syntactically bogus RUTs.

## Gates (local)

- `pytest -q` — **269 passed** (baseline 171 + 98 new), coverage **99.79 %** on the package aggregate, **100 %** on each new resource module (`sanctions` 42 stmts / 10 branches, `registries` 49 stmts / 8 branches, `regulations` 28 stmts / 0 branches) measured with a scoped coverage config that bypasses the `pyproject.toml` `omit` safeguard Instance A placed for parallel development.
- `ruff check .` — clean.
- `ruff format --check .` — clean.
- `mypy --strict cerberus_compliance/` — no issues.

## Test plan

- [x] Sync + async `list`, `get`, `iter_all` for each resource.
- [x] Cursor-pagination gotcha respected (cursor-specific routes registered before no-cursor ones).
- [x] `ONU` -> `UN` normalisation in both `list` and `iter_all`.
- [x] `lookup_rut` happy-path + all syntactic failure modes.
- [x] `None`-valued kwargs are dropped from the wire URL in `iter_all` for all three resources.
- [x] Full package suite still green; no regressions on A's 171 foundation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)