### PR TITLE
feat: entities + persons + material_events resources

### DIFF
--- a/cerberus_compliance/client.py
+++ b/cerberus_compliance/client.py
@@ -30,6 +30,18 @@ import httpx
 
 from cerberus_compliance.auth import ApiKeyAuth, resolve_api_key
 from cerberus_compliance.errors import CerberusAPIError
+from cerberus_compliance.resources.entities import (
+    AsyncEntitiesResource,
+    EntitiesResource,
+)
+from cerberus_compliance.resources.material_events import (
+    AsyncMaterialEventsResource,
+    MaterialEventsResource,
+)
+from cerberus_compliance.resources.persons import (
+    AsyncPersonsResource,
+    PersonsResource,
+)
 from cerberus_compliance.retry import RetryConfig, backoff_seconds, should_retry
 
 __all__ = [
@@ -102,6 +114,9 @@ class CerberusClient:
             timeout=timeout,
             auth=ApiKeyAuth(self.api_key),
         )
+        self.entities: EntitiesResource = EntitiesResource(self)
+        self.persons: PersonsResource = PersonsResource(self)
+        self.material_events: MaterialEventsResource = MaterialEventsResource(self)
         # Sub-resources are wired below by Instances B/C — keep this exact marker:
         # INSERT RESOURCES HERE
 
@@ -245,6 +260,9 @@ class AsyncCerberusClient:
             timeout=timeout,
             auth=ApiKeyAuth(self.api_key),
         )
+        self.entities: AsyncEntitiesResource = AsyncEntitiesResource(self)
+        self.persons: AsyncPersonsResource = AsyncPersonsResource(self)
+        self.material_events: AsyncMaterialEventsResource = AsyncMaterialEventsResource(self)
         # Sub-resources are wired below by Instances B/C — keep this exact marker:
         # INSERT RESOURCES HERE
 

--- a/cerberus_compliance/resources/__init__.py
+++ b/cerberus_compliance/resources/__init__.py
@@ -1,0 +1,26 @@
+"""Public re-exports for the ``cerberus_compliance.resources`` package."""
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.entities import (
+    AsyncEntitiesResource,
+    EntitiesResource,
+)
+from cerberus_compliance.resources.material_events import (
+    AsyncMaterialEventsResource,
+    MaterialEventsResource,
+)
+from cerberus_compliance.resources.persons import (
+    AsyncPersonsResource,
+    PersonsResource,
+)
+
+__all__ = [
+    "AsyncBaseResource",
+    "AsyncEntitiesResource",
+    "AsyncMaterialEventsResource",
+    "AsyncPersonsResource",
+    "BaseResource",
+    "EntitiesResource",
+    "MaterialEventsResource",
+    "PersonsResource",
+]

--- a/cerberus_compliance/resources/entities.py
+++ b/cerberus_compliance/resources/entities.py
@@ -1,0 +1,159 @@
+"""Typed accessors for the Cerberus Compliance ``/entities`` resource.
+
+Entities are Chilean legal persons (companies, foundations, public
+agencies) identified by their RUT. This module exposes the synchronous
+:class:`EntitiesResource` and its asynchronous mirror
+:class:`AsyncEntitiesResource`; both delegate to the shared base classes
+in :mod:`cerberus_compliance.resources._base`.
+
+Nested collection endpoints (``material-events``, ``sanctions``,
+``directors``, ``regulations``) parse the response envelope
+defensively: a missing ``data`` key, a non-list ``data`` value, or
+non-dict items in the list are all silently collapsed to an empty list
+(or skipped), so callers never receive malformed payloads.
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncEntitiesResource", "EntitiesResource"]
+
+
+def _extract_data_list(body: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a list of dicts from a ``{"data": [...]}``-shaped envelope.
+
+    Returns ``[]`` when ``data`` is missing or not a list, and drops any
+    non-dict items in a valid list so the result is always a concrete
+    ``list[dict[str, Any]]``.
+    """
+    data = body.get("data")
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+class EntitiesResource(BaseResource):
+    """Synchronous accessor for the ``/entities`` endpoint family."""
+
+    _path_prefix = "/entities"
+
+    def list(
+        self,
+        *,
+        rut: str | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Return the first page of entities, optionally filtered.
+
+        Args:
+            rut: Chilean RUT filter (e.g. ``"76123456-7"``).
+            limit: Maximum number of entities to return on this page.
+        """
+        params: dict[str, Any] = {}
+        if rut is not None:
+            params["rut"] = rut
+        if limit is not None:
+            params["limit"] = limit
+        return self._list(params=params or None)
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single entity by RUT (``GET /entities/<id_>``)."""
+        return self._get(id_)
+
+    def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """List material events (``hechos esenciales``) for an entity."""
+        body = self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/material-events"
+        )
+        return _extract_data_list(body)
+
+    def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """List sanctions observed against an entity."""
+        body = self._client._request("GET", f"{self._path_prefix}/{id_}/sanctions")
+        return _extract_data_list(body)
+
+    def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """List the current board of directors for an entity."""
+        body = self._client._request("GET", f"{self._path_prefix}/{id_}/directors")
+        return _extract_data_list(body)
+
+    def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """List regulatory obligations applicable to an entity."""
+        body = self._client._request("GET", f"{self._path_prefix}/{id_}/regulations")
+        return _extract_data_list(body)
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Iterate through every entity, transparently paginating.
+
+        Forwards arbitrary ``**filters`` on every page request. Returns
+        the underlying generator directly (instead of ``yield from``) so
+        callers get a plain sync generator without the extra frame.
+        """
+        return self._iter_all(params=filters or None)
+
+
+class AsyncEntitiesResource(AsyncBaseResource):
+    """Asynchronous accessor for the ``/entities`` endpoint family."""
+
+    _path_prefix = "/entities"
+
+    async def list(
+        self,
+        *,
+        rut: str | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`EntitiesResource.list`."""
+        params: dict[str, Any] = {}
+        if rut is not None:
+            params["rut"] = rut
+        if limit is not None:
+            params["limit"] = limit
+        return await self._list(params=params or None)
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`EntitiesResource.get`."""
+        return await self._get(id_)
+
+    async def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`EntitiesResource.material_events`."""
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/material-events"
+        )
+        return _extract_data_list(body)
+
+    async def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`EntitiesResource.sanctions`."""
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/sanctions"
+        )
+        return _extract_data_list(body)
+
+    async def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`EntitiesResource.directors`."""
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/directors"
+        )
+        return _extract_data_list(body)
+
+    async def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`EntitiesResource.regulations`."""
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/regulations"
+        )
+        return _extract_data_list(body)
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator over every entity; mirrors :meth:`EntitiesResource.iter_all`.
+
+        Intentionally a non-``async`` method that returns the underlying
+        async generator directly — matches the idiom used in the base
+        resource tests and keeps ``async for`` usage natural at the call
+        site.
+        """
+        return self._iter_all(params=filters or None)

--- a/cerberus_compliance/resources/entities.py
+++ b/cerberus_compliance/resources/entities.py
@@ -67,9 +67,7 @@ class EntitiesResource(BaseResource):
 
     def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List material events (``hechos esenciales``) for an entity."""
-        body = self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/material-events"
-        )
+        body = self._client._request("GET", f"{self._path_prefix}/{id_}/material-events")
         return _extract_data_list(body)
 
     def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
@@ -122,30 +120,22 @@ class AsyncEntitiesResource(AsyncBaseResource):
 
     async def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.material_events`."""
-        body = await self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/material-events"
-        )
+        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/material-events")
         return _extract_data_list(body)
 
     async def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.sanctions`."""
-        body = await self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/sanctions"
-        )
+        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/sanctions")
         return _extract_data_list(body)
 
     async def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.directors`."""
-        body = await self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/directors"
-        )
+        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/directors")
         return _extract_data_list(body)
 
     async def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.regulations`."""
-        body = await self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/regulations"
-        )
+        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/regulations")
         return _extract_data_list(body)
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:

--- a/cerberus_compliance/resources/entities.py
+++ b/cerberus_compliance/resources/entities.py
@@ -68,7 +68,9 @@ class EntitiesResource(BaseResource):
 
     def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List material events (``hechos esenciales``) for an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events")
+        body = self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events"
+        )
         return _extract_data_list(body)
 
     def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
@@ -83,7 +85,9 @@ class EntitiesResource(BaseResource):
 
     def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List regulatory obligations applicable to an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations")
+        body = self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations"
+        )
         return _extract_data_list(body)
 
     def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
@@ -121,22 +125,30 @@ class AsyncEntitiesResource(AsyncBaseResource):
 
     async def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.material_events`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events")
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events"
+        )
         return _extract_data_list(body)
 
     async def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.sanctions`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/sanctions")
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/sanctions"
+        )
         return _extract_data_list(body)
 
     async def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.directors`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/directors")
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/directors"
+        )
         return _extract_data_list(body)
 
     async def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.regulations`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations")
+        body = await self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations"
+        )
         return _extract_data_list(body)
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:

--- a/cerberus_compliance/resources/entities.py
+++ b/cerberus_compliance/resources/entities.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import builtins
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
+from urllib.parse import quote
 
 from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
 
@@ -67,22 +68,22 @@ class EntitiesResource(BaseResource):
 
     def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List material events (``hechos esenciales``) for an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{id_}/material-events")
+        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events")
         return _extract_data_list(body)
 
     def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List sanctions observed against an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{id_}/sanctions")
+        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/sanctions")
         return _extract_data_list(body)
 
     def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List the current board of directors for an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{id_}/directors")
+        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/directors")
         return _extract_data_list(body)
 
     def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
         """List regulatory obligations applicable to an entity."""
-        body = self._client._request("GET", f"{self._path_prefix}/{id_}/regulations")
+        body = self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations")
         return _extract_data_list(body)
 
     def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
@@ -120,22 +121,22 @@ class AsyncEntitiesResource(AsyncBaseResource):
 
     async def material_events(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.material_events`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/material-events")
+        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/material-events")
         return _extract_data_list(body)
 
     async def sanctions(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.sanctions`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/sanctions")
+        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/sanctions")
         return _extract_data_list(body)
 
     async def directors(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.directors`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/directors")
+        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/directors")
         return _extract_data_list(body)
 
     async def regulations(self, id_: str) -> builtins.list[dict[str, Any]]:
         """Async variant of :meth:`EntitiesResource.regulations`."""
-        body = await self._client._request("GET", f"{self._path_prefix}/{id_}/regulations")
+        body = await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulations")
         return _extract_data_list(body)
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:

--- a/cerberus_compliance/resources/material_events.py
+++ b/cerberus_compliance/resources/material_events.py
@@ -1,0 +1,133 @@
+"""Typed accessors for the Cerberus Compliance ``/material-events`` resource.
+
+Material events (``hechos esenciales`` in Chilean regulatory parlance) are
+disclosure filings that listed entities must submit to the CMF whenever an
+event materially affects their securities or financial position. This module
+exposes the synchronous :class:`MaterialEventsResource` and its asynchronous
+mirror :class:`AsyncMaterialEventsResource`; both delegate to the shared base
+classes in :mod:`cerberus_compliance.resources._base`.
+
+Time filters (``since`` / ``until``) accept either ISO-8601 strings or
+timezone-aware :class:`datetime.datetime` values; datetimes are serialized via
+:meth:`datetime.datetime.isoformat` before being forwarded as query params,
+strings pass through unchanged. See :func:`_coerce_params`.
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import AsyncIterator, Iterator
+from datetime import datetime
+from typing import Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncMaterialEventsResource", "MaterialEventsResource"]
+
+
+def _coerce_params(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Serialize datetime values in a params dict to ISO-8601 strings.
+
+    Returns ``None`` when ``raw`` is ``None`` or empty so callers can pass the
+    result straight through to ``_request(..., params=...)``. For non-empty
+    inputs, returns a fresh dict where any :class:`datetime.datetime` value is
+    replaced by ``value.isoformat()``; other value types pass through
+    untouched.
+    """
+    if not raw:
+        return None
+    coerced: dict[str, Any] = {}
+    for key, value in raw.items():
+        if isinstance(value, datetime):
+            coerced[key] = value.isoformat()
+        else:
+            coerced[key] = value
+    return coerced
+
+
+class MaterialEventsResource(BaseResource):
+    """Synchronous accessor for the ``/material-events`` endpoint family."""
+
+    _path_prefix = "/material-events"
+
+    def list(
+        self,
+        *,
+        entity_id: str | None = None,
+        since: str | datetime | None = None,
+        until: str | datetime | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Return the first page of material events, optionally filtered.
+
+        Args:
+            entity_id: Restrict to events for a single entity (by RUT).
+            since: Lower bound on publication timestamp. ``datetime`` values
+                are serialized to ISO-8601; strings are forwarded verbatim.
+            until: Upper bound on publication timestamp. Same coercion rule
+                as ``since``.
+            limit: Maximum number of events to return on this page.
+        """
+        raw: dict[str, Any] = {}
+        if entity_id is not None:
+            raw["entity_id"] = entity_id
+        if since is not None:
+            raw["since"] = since
+        if until is not None:
+            raw["until"] = until
+        if limit is not None:
+            raw["limit"] = limit
+        return self._list(params=_coerce_params(raw))
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single material event by ID (``GET /material-events/<id_>``)."""
+        return self._get(id_)
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Iterate through every material event, transparently paginating.
+
+        Forwards arbitrary ``**filters`` on every page request, applying the
+        same datetime-to-ISO coercion rule as :meth:`list`. Returns the
+        underlying generator directly so callers get a plain sync generator.
+        """
+        return self._iter_all(params=_coerce_params(filters))
+
+
+class AsyncMaterialEventsResource(AsyncBaseResource):
+    """Asynchronous accessor for the ``/material-events`` endpoint family."""
+
+    _path_prefix = "/material-events"
+
+    async def list(
+        self,
+        *,
+        entity_id: str | None = None,
+        since: str | datetime | None = None,
+        until: str | datetime | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`MaterialEventsResource.list`."""
+        raw: dict[str, Any] = {}
+        if entity_id is not None:
+            raw["entity_id"] = entity_id
+        if since is not None:
+            raw["since"] = since
+        if until is not None:
+            raw["until"] = until
+        if limit is not None:
+            raw["limit"] = limit
+        return await self._list(params=_coerce_params(raw))
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`MaterialEventsResource.get`."""
+        return await self._get(id_)
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator over every material event.
+
+        Intentionally a non-``async`` method that returns the underlying async
+        generator directly, so callers can write ``async for`` at the call
+        site without an extra ``await``. Applies the same datetime-to-ISO
+        coercion rule as :meth:`MaterialEventsResource.iter_all`.
+        """
+        return self._iter_all(params=_coerce_params(filters))

--- a/cerberus_compliance/resources/persons.py
+++ b/cerberus_compliance/resources/persons.py
@@ -58,9 +58,7 @@ class PersonsResource(BaseResource):
         returns a single object (not a list envelope), so the parsed
         body is returned as-is.
         """
-        return self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/regulatory-profile"
-        )
+        return self._client._request("GET", f"{self._path_prefix}/{id_}/regulatory-profile")
 
     def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
         """Iterate through every person, transparently paginating.
@@ -98,9 +96,7 @@ class AsyncPersonsResource(AsyncBaseResource):
 
     async def regulatory_profile(self, id_: str) -> dict[str, Any]:
         """Async variant of :meth:`PersonsResource.regulatory_profile`."""
-        return await self._client._request(
-            "GET", f"{self._path_prefix}/{id_}/regulatory-profile"
-        )
+        return await self._client._request("GET", f"{self._path_prefix}/{id_}/regulatory-profile")
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
         """Async iterator over every person; mirror of :meth:`PersonsResource.iter_all`.

--- a/cerberus_compliance/resources/persons.py
+++ b/cerberus_compliance/resources/persons.py
@@ -1,0 +1,112 @@
+"""Typed accessors for the Cerberus Compliance ``/persons`` resource.
+
+Persons are Chilean natural persons (``personas naturales``), identified
+by their RUT. This module exposes the synchronous
+:class:`PersonsResource` and its asynchronous mirror
+:class:`AsyncPersonsResource`; both delegate to the shared base classes
+in :mod:`cerberus_compliance.resources._base`.
+
+The ``/persons/<id>/regulatory-profile`` endpoint returns a single
+object (not a ``{"data": [...]}`` envelope) describing the person's
+compliance-risk signals — PEP status, sanctions score, watchlist hits,
+etc. — and is returned verbatim to the caller.
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncPersonsResource", "PersonsResource"]
+
+
+class PersonsResource(BaseResource):
+    """Synchronous accessor for the ``/persons`` endpoint family."""
+
+    _path_prefix = "/persons"
+
+    def list(
+        self,
+        *,
+        rut: str | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Return the first page of persons, optionally filtered.
+
+        Args:
+            rut: Chilean RUT filter (e.g. ``"7890123-4"``).
+            limit: Maximum number of persons to return on this page.
+        """
+        params: dict[str, Any] = {}
+        if rut is not None:
+            params["rut"] = rut
+        if limit is not None:
+            params["limit"] = limit
+        return self._list(params=params or None)
+
+    def get(self, id_: str) -> dict[str, Any]:
+        """Fetch a single person by RUT (``GET /persons/<id_>``)."""
+        return self._get(id_)
+
+    def regulatory_profile(self, id_: str) -> dict[str, Any]:
+        """Return the full compliance profile for a person.
+
+        Issues ``GET /persons/<id_>/regulatory-profile``. The endpoint
+        returns a single object (not a list envelope), so the parsed
+        body is returned as-is.
+        """
+        return self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/regulatory-profile"
+        )
+
+    def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
+        """Iterate through every person, transparently paginating.
+
+        Forwards arbitrary ``**filters`` on every page request. Returns
+        the underlying generator directly (rather than ``yield from``)
+        so the method itself is a plain sync function that hands back a
+        generator.
+        """
+        return self._iter_all(params=filters or None)
+
+
+class AsyncPersonsResource(AsyncBaseResource):
+    """Asynchronous accessor for the ``/persons`` endpoint family."""
+
+    _path_prefix = "/persons"
+
+    async def list(
+        self,
+        *,
+        rut: str | None = None,
+        limit: int | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Async variant of :meth:`PersonsResource.list`."""
+        params: dict[str, Any] = {}
+        if rut is not None:
+            params["rut"] = rut
+        if limit is not None:
+            params["limit"] = limit
+        return await self._list(params=params or None)
+
+    async def get(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`PersonsResource.get`."""
+        return await self._get(id_)
+
+    async def regulatory_profile(self, id_: str) -> dict[str, Any]:
+        """Async variant of :meth:`PersonsResource.regulatory_profile`."""
+        return await self._client._request(
+            "GET", f"{self._path_prefix}/{id_}/regulatory-profile"
+        )
+
+    def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator over every person; mirror of :meth:`PersonsResource.iter_all`.
+
+        Intentionally a non-``async`` method that returns the underlying
+        async generator directly, so callers can write ``async for`` at
+        the call site without an extra ``await``.
+        """
+        return self._iter_all(params=filters or None)

--- a/cerberus_compliance/resources/persons.py
+++ b/cerberus_compliance/resources/persons.py
@@ -59,7 +59,9 @@ class PersonsResource(BaseResource):
         returns a single object (not a list envelope), so the parsed
         body is returned as-is.
         """
-        return self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile")
+        return self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile"
+        )
 
     def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
         """Iterate through every person, transparently paginating.
@@ -97,7 +99,9 @@ class AsyncPersonsResource(AsyncBaseResource):
 
     async def regulatory_profile(self, id_: str) -> dict[str, Any]:
         """Async variant of :meth:`PersonsResource.regulatory_profile`."""
-        return await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile")
+        return await self._client._request(
+            "GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile"
+        )
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
         """Async iterator over every person; mirror of :meth:`PersonsResource.iter_all`.

--- a/cerberus_compliance/resources/persons.py
+++ b/cerberus_compliance/resources/persons.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import builtins
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
+from urllib.parse import quote
 
 from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
 
@@ -58,7 +59,7 @@ class PersonsResource(BaseResource):
         returns a single object (not a list envelope), so the parsed
         body is returned as-is.
         """
-        return self._client._request("GET", f"{self._path_prefix}/{id_}/regulatory-profile")
+        return self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile")
 
     def iter_all(self, **filters: Any) -> Iterator[dict[str, Any]]:
         """Iterate through every person, transparently paginating.
@@ -96,7 +97,7 @@ class AsyncPersonsResource(AsyncBaseResource):
 
     async def regulatory_profile(self, id_: str) -> dict[str, Any]:
         """Async variant of :meth:`PersonsResource.regulatory_profile`."""
-        return await self._client._request("GET", f"{self._path_prefix}/{id_}/regulatory-profile")
+        return await self._client._request("GET", f"{self._path_prefix}/{quote(id_, safe='')}/regulatory-profile")
 
     def iter_all(self, **filters: Any) -> AsyncIterator[dict[str, Any]]:
         """Async iterator over every person; mirror of :meth:`PersonsResource.iter_all`.

--- a/tests/resources/test_entities.py
+++ b/tests/resources/test_entities.py
@@ -219,6 +219,22 @@ class TestSyncEntitiesResource:
         finally:
             client.close()
 
+    # ------------------------------------------------------------------
+    # Path-traversal hardening (OWASP A01)
+    # ------------------------------------------------------------------
+
+    def test_path_traversal_id_is_percent_encoded(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        """User-supplied id_ containing '../' must be percent-encoded, not traversed."""
+        route = respx_mock.get("/entities/..%2Fadmin/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        resource = EntitiesResource(sync_client)
+        result = resource.sanctions("../admin")
+        assert result == []
+        assert route.called
+
 
 # ---------------------------------------------------------------------------
 # Async tests
@@ -336,3 +352,19 @@ class TestAsyncEntitiesResource:
         async for item in resource.iter_all(rut="76123456-7"):
             collected.append(item)
         assert collected == [{"id": "a"}, {"id": "b"}]
+
+    # ------------------------------------------------------------------
+    # Path-traversal hardening (OWASP A01)
+    # ------------------------------------------------------------------
+
+    async def test_path_traversal_id_is_percent_encoded(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        """User-supplied id_ containing '../' must be percent-encoded, not traversed."""
+        route = respx_mock.get("/entities/..%2Fadmin/material-events").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        result = await resource.material_events("../admin")
+        assert result == []
+        assert route.called

--- a/tests/resources/test_entities.py
+++ b/tests/resources/test_entities.py
@@ -38,9 +38,7 @@ class TestSyncEntitiesResource:
         assert resource.list() == [{"id": "e1"}, {"id": "e2"}]
         assert route.called
 
-    def test_list_with_rut(
-        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
-    ) -> None:
+    def test_list_with_rut(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
         route = respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
             return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": None})
         )
@@ -61,9 +59,7 @@ class TestSyncEntitiesResource:
     def test_list_with_all_filters(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        route = respx_mock.get(
-            "/entities", params={"rut": "76123456-7", "limit": "10"}
-        ).mock(
+        route = respx_mock.get("/entities", params={"rut": "76123456-7", "limit": "10"}).mock(
             return_value=httpx.Response(200, json={"data": [{"id": "eZ"}], "next": None})
         )
         resource = EntitiesResource(sync_client)
@@ -74,9 +70,7 @@ class TestSyncEntitiesResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities/76123456-7").mock(
-            return_value=httpx.Response(
-                200, json={"id": "76123456-7", "name": "Acme SpA"}
-            )
+            return_value=httpx.Response(200, json={"id": "76123456-7", "name": "Acme SpA"})
         )
         resource = EntitiesResource(sync_client)
         assert resource.get("76123456-7") == {"id": "76123456-7", "name": "Acme SpA"}
@@ -115,9 +109,7 @@ class TestSyncEntitiesResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities/76123456-7/material-events").mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"ok": 1}, "bad", 42]}
-            )
+            return_value=httpx.Response(200, json={"data": [{"ok": 1}, "bad", 42]})
         )
         resource = EntitiesResource(sync_client)
         assert resource.material_events("76123456-7") == [{"ok": 1}]
@@ -135,9 +127,7 @@ class TestSyncEntitiesResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities/76123456-7/directors").mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"name": "Jane"}, {"name": "John"}]}
-            )
+            return_value=httpx.Response(200, json={"data": [{"name": "Jane"}, {"name": "John"}]})
         )
         resource = EntitiesResource(sync_client)
         assert resource.directors("76123456-7") == [
@@ -160,14 +150,10 @@ class TestSyncEntitiesResource:
         # Specific (cursor) route registered FIRST so the dispatcher hits
         # it before the bare subset match.
         page2 = respx_mock.get("/entities", params={"cursor": "tok2"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e2"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "e2"}], "next": None})
         )
         page1 = respx_mock.get("/entities", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e1"}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": "tok2"})
         )
         resource = EntitiesResource(sync_client)
         items = list(resource.iter_all())
@@ -178,17 +164,11 @@ class TestSyncEntitiesResource:
     def test_iter_all_forwards_filters(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        page2 = respx_mock.get(
-            "/entities", params={"rut": "76123456-7", "cursor": "n2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
+        page2 = respx_mock.get("/entities", params={"rut": "76123456-7", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
         )
         page1 = respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = EntitiesResource(sync_client)
         items = list(resource.iter_all(rut="76123456-7"))
@@ -250,9 +230,7 @@ class TestAsyncEntitiesResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e1"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": None})
         )
         resource = AsyncEntitiesResource(async_client)
         assert await resource.list(rut="76123456-7") == [{"id": "e1"}]
@@ -260,9 +238,7 @@ class TestAsyncEntitiesResource:
     async def test_async_list_with_all_filters(
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.get(
-            "/entities", params={"rut": "76123456-7", "limit": "5"}
-        ).mock(
+        respx_mock.get("/entities", params={"rut": "76123456-7", "limit": "5"}).mock(
             return_value=httpx.Response(200, json={"data": [{"id": "eZ"}], "next": None})
         )
         resource = AsyncEntitiesResource(async_client)
@@ -308,9 +284,7 @@ class TestAsyncEntitiesResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities/76123456-7/sanctions").mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "s1"}, "skip-me", 99]}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "s1"}, "skip-me", 99]})
         )
         resource = AsyncEntitiesResource(async_client)
         assert await resource.sanctions("76123456-7") == [{"id": "s1"}]
@@ -337,14 +311,10 @@ class TestAsyncEntitiesResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/entities", params={"cursor": "tok2"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 2}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 2}], "next": None})
         )
         respx_mock.get("/entities", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 1}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 1}], "next": "tok2"})
         )
         resource = AsyncEntitiesResource(async_client)
         collected: list[dict[str, Any]] = []
@@ -355,17 +325,11 @@ class TestAsyncEntitiesResource:
     async def test_async_iter_all_forwards_filters(
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.get(
-            "/entities", params={"rut": "76123456-7", "cursor": "n2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
+        respx_mock.get("/entities", params={"rut": "76123456-7", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
         )
         respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = AsyncEntitiesResource(async_client)
         collected: list[dict[str, Any]] = []

--- a/tests/resources/test_entities.py
+++ b/tests/resources/test_entities.py
@@ -1,0 +1,374 @@
+"""TDD tests for :mod:`cerberus_compliance.resources.entities`.
+
+Covers :class:`EntitiesResource` and :class:`AsyncEntitiesResource`: the
+``list`` / ``get`` / ``material_events`` / ``sanctions`` / ``directors``
+/ ``regulations`` / ``iter_all`` surface, defensive envelope handling on
+the nested-list endpoints, and propagation of API errors.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError, RateLimitError
+from cerberus_compliance.resources.entities import AsyncEntitiesResource, EntitiesResource
+from cerberus_compliance.retry import RetryConfig
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncEntitiesResource:
+    def test_list_no_params(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/entities").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "e1"}, {"id": "e2"}], "next": None},
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.list() == [{"id": "e1"}, {"id": "e2"}]
+        assert route.called
+
+    def test_list_with_rut(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": None})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.list(rut="76123456-7") == [{"id": "e1"}]
+        assert route.called
+
+    def test_list_with_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/entities", params={"limit": "25"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "e9"}], "next": None})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.list(limit=25) == [{"id": "e9"}]
+        assert route.called
+
+    def test_list_with_all_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/entities", params={"rut": "76123456-7", "limit": "10"}
+        ).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "eZ"}], "next": None})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.list(rut="76123456-7", limit=10) == [{"id": "eZ"}]
+        assert route.called
+
+    def test_get_returns_entity(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7").mock(
+            return_value=httpx.Response(
+                200, json={"id": "76123456-7", "name": "Acme SpA"}
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.get("76123456-7") == {"id": "76123456-7", "name": "Acme SpA"}
+
+    def test_material_events_happy_path(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "me1"}, {"id": "me2"}]},
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.material_events("76123456-7") == [{"id": "me1"}, {"id": "me2"}]
+
+    def test_material_events_missing_data_returns_empty(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.material_events("76123456-7") == []
+
+    def test_material_events_data_not_list_returns_empty(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(200, json={"data": "oops"})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.material_events("76123456-7") == []
+
+    def test_material_events_drops_non_dict_items(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"ok": 1}, "bad", 42]}
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.material_events("76123456-7") == [{"ok": 1}]
+
+    def test_sanctions_happy_path(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/sanctions").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "s1"}]})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.sanctions("76123456-7") == [{"id": "s1"}]
+
+    def test_directors_happy_path(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/directors").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"name": "Jane"}, {"name": "John"}]}
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.directors("76123456-7") == [
+            {"name": "Jane"},
+            {"name": "John"},
+        ]
+
+    def test_regulations_happy_path(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/regulations").mock(
+            return_value=httpx.Response(200, json={"data": [{"code": "CMF-001"}]})
+        )
+        resource = EntitiesResource(sync_client)
+        assert resource.regulations("76123456-7") == [{"code": "CMF-001"}]
+
+    def test_iter_all_no_filters_paginates_two_pages(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Specific (cursor) route registered FIRST so the dispatcher hits
+        # it before the bare subset match.
+        page2 = respx_mock.get("/entities", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e2"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get("/entities", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e1"}], "next": "tok2"}
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        items = list(resource.iter_all())
+        assert items == [{"id": "e1"}, {"id": "e2"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_forwards_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page2 = respx_mock.get(
+            "/entities", params={"rut": "76123456-7", "cursor": "n2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        items = list(resource.iter_all(rut="76123456-7"))
+        assert items == [{"id": "a"}, {"id": "b"}]
+        assert page1.called
+        assert page2.called
+
+    def test_get_propagates_404(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "type": "about:blank",
+                    "title": "Not Found",
+                    "status": 404,
+                    "detail": "Entity missing",
+                },
+            )
+        )
+        resource = EntitiesResource(sync_client)
+        with pytest.raises(CerberusAPIError) as exc_info:
+            resource.get("missing")
+        assert exc_info.value.status == 404
+
+    def test_get_propagates_429(
+        self, api_key: str, base_url: str, respx_mock: respx.MockRouter
+    ) -> None:
+        # One-off client with no retries so the 429 surfaces without delay.
+        client = CerberusClient(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=2.0,
+            retry=RetryConfig(max_attempts=1, base_delay_ms=1),
+        )
+        try:
+            respx_mock.get("/entities/rate-limited").mock(
+                return_value=httpx.Response(
+                    429,
+                    headers={"retry-after": "1"},
+                    json={"title": "Too Many Requests", "status": 429},
+                )
+            )
+            resource = EntitiesResource(client)
+            with pytest.raises(RateLimitError):
+                resource.get("rate-limited")
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncEntitiesResource:
+    async def test_async_list_returns_data(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e1"}], "next": None}
+            )
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.list(rut="76123456-7") == [{"id": "e1"}]
+
+    async def test_async_list_with_all_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/entities", params={"rut": "76123456-7", "limit": "5"}
+        ).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "eZ"}], "next": None})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.list(rut="76123456-7", limit=5) == [{"id": "eZ"}]
+
+    async def test_async_list_no_params(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "e0"}], "next": None})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.list() == [{"id": "e0"}]
+
+    async def test_async_get_returns_entity(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7").mock(
+            return_value=httpx.Response(200, json={"id": "76123456-7"})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.get("76123456-7") == {"id": "76123456-7"}
+
+    async def test_async_material_events_happy_path(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "me1"}]})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.material_events("76123456-7") == [{"id": "me1"}]
+
+    async def test_async_material_events_missing_data_returns_empty(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/material-events").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.material_events("76123456-7") == []
+
+    async def test_async_sanctions_happy_path(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/sanctions").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "s1"}, "skip-me", 99]}
+            )
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.sanctions("76123456-7") == [{"id": "s1"}]
+
+    async def test_async_directors_happy_path(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/directors").mock(
+            return_value=httpx.Response(200, json={"data": [{"name": "Jane"}]})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.directors("76123456-7") == [{"name": "Jane"}]
+
+    async def test_async_regulations_happy_path(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities/76123456-7/regulations").mock(
+            return_value=httpx.Response(200, json={"data": "not-a-list"})
+        )
+        resource = AsyncEntitiesResource(async_client)
+        assert await resource.regulations("76123456-7") == []
+
+    async def test_async_iter_all_paginates(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/entities", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 2}], "next": None}
+            )
+        )
+        respx_mock.get("/entities", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 1}], "next": "tok2"}
+            )
+        )
+        resource = AsyncEntitiesResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            collected.append(item)
+        assert collected == [{"id": 1}, {"id": 2}]
+
+    async def test_async_iter_all_forwards_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/entities", params={"rut": "76123456-7", "cursor": "n2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        respx_mock.get("/entities", params={"rut": "76123456-7"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = AsyncEntitiesResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(rut="76123456-7"):
+            collected.append(item)
+        assert collected == [{"id": "a"}, {"id": "b"}]

--- a/tests/resources/test_material_events.py
+++ b/tests/resources/test_material_events.py
@@ -45,12 +45,8 @@ class TestSyncMaterialEventsResource:
     def test_list_with_entity_id(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        route = respx_mock.get(
-            "/material-events", params={"entity_id": "76123456-7"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evt1"}], "next": None}
-            )
+        route = respx_mock.get("/material-events", params={"entity_id": "76123456-7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "evt1"}], "next": None})
         )
         resource = MaterialEventsResource(sync_client)
         assert resource.list(entity_id="76123456-7") == [{"id": "evt1"}]
@@ -59,12 +55,8 @@ class TestSyncMaterialEventsResource:
     def test_list_with_since_string(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        route = respx_mock.get(
-            "/material-events", params={"since": "2026-01-01T00:00:00Z"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evtA"}], "next": None}
-            )
+        route = respx_mock.get("/material-events", params={"since": "2026-01-01T00:00:00Z"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "evtA"}], "next": None})
         )
         resource = MaterialEventsResource(sync_client)
         assert resource.list(since="2026-01-01T00:00:00Z") == [{"id": "evtA"}]
@@ -75,11 +67,7 @@ class TestSyncMaterialEventsResource:
     ) -> None:
         route = respx_mock.get(
             "/material-events", params={"since": "2026-01-01T00:00:00+00:00"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evtB"}], "next": None}
-            )
-        )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "evtB"}], "next": None}))
         resource = MaterialEventsResource(sync_client)
         result = resource.list(since=datetime(2026, 1, 1, tzinfo=timezone.utc))
         assert result == [{"id": "evtB"}]
@@ -90,11 +78,7 @@ class TestSyncMaterialEventsResource:
     ) -> None:
         route = respx_mock.get(
             "/material-events", params={"until": "2026-04-01T00:00:00+00:00"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evtC"}], "next": None}
-            )
-        )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "evtC"}], "next": None}))
         resource = MaterialEventsResource(sync_client)
         result = resource.list(until=datetime(2026, 4, 1, tzinfo=timezone.utc))
         assert result == [{"id": "evtC"}]
@@ -103,12 +87,8 @@ class TestSyncMaterialEventsResource:
     def test_list_with_limit(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        route = respx_mock.get(
-            "/material-events", params={"limit": "10"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evtD"}], "next": None}
-            )
+        route = respx_mock.get("/material-events", params={"limit": "10"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "evtD"}], "next": None})
         )
         resource = MaterialEventsResource(sync_client)
         assert resource.list(limit=10) == [{"id": "evtD"}]
@@ -125,11 +105,7 @@ class TestSyncMaterialEventsResource:
                 "until": "2026-04-01T00:00:00Z",
                 "limit": "50",
             },
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "evtAll"}], "next": None}
-            )
-        )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "evtAll"}], "next": None}))
         resource = MaterialEventsResource(sync_client)
         result = resource.list(
             entity_id="76123456-7",
@@ -144,9 +120,7 @@ class TestSyncMaterialEventsResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/material-events/evt_abc").mock(
-            return_value=httpx.Response(
-                200, json={"id": "evt_abc", "headline": "Profit warning"}
-            )
+            return_value=httpx.Response(200, json={"id": "evt_abc", "headline": "Profit warning"})
         )
         resource = MaterialEventsResource(sync_client)
         assert resource.get("evt_abc") == {
@@ -160,17 +134,11 @@ class TestSyncMaterialEventsResource:
         # Register the more specific (cursor) route FIRST — respx matches
         # params as a subset, so ``params={}`` would otherwise swallow the
         # cursor request.
-        page2 = respx_mock.get(
-            "/material-events", params={"cursor": "tok2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e2"}], "next": None}
-            )
+        page2 = respx_mock.get("/material-events", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "e2"}], "next": None})
         )
         page1 = respx_mock.get("/material-events", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e1"}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": "tok2"})
         )
         resource = MaterialEventsResource(sync_client)
         items = list(resource.iter_all())
@@ -184,17 +152,9 @@ class TestSyncMaterialEventsResource:
         page2 = respx_mock.get(
             "/material-events",
             params={"entity_id": "76123456-7", "cursor": "n2"},
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
-        )
-        page1 = respx_mock.get(
-            "/material-events", params={"entity_id": "76123456-7"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None}))
+        page1 = respx_mock.get("/material-events", params={"entity_id": "76123456-7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = MaterialEventsResource(sync_client)
         items = list(resource.iter_all(entity_id="76123456-7"))
@@ -206,17 +166,11 @@ class TestSyncMaterialEventsResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         iso = "2026-01-01T00:00:00+00:00"
-        route = respx_mock.get(
-            "/material-events", params={"since": iso}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "only"}], "next": None}
-            )
+        route = respx_mock.get("/material-events", params={"since": iso}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "only"}], "next": None})
         )
         resource = MaterialEventsResource(sync_client)
-        items = list(
-            resource.iter_all(since=datetime(2026, 1, 1, tzinfo=timezone.utc))
-        )
+        items = list(resource.iter_all(since=datetime(2026, 1, 1, tzinfo=timezone.utc)))
         assert items == [{"id": "only"}]
         assert route.called
 
@@ -272,12 +226,8 @@ class TestAsyncMaterialEventsResource:
     async def test_async_list_returns_data(
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.get(
-            "/material-events", params={"entity_id": "76123456-7"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "e1"}], "next": None}
-            )
+        respx_mock.get("/material-events", params={"entity_id": "76123456-7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "e1"}], "next": None})
         )
         resource = AsyncMaterialEventsResource(async_client)
         assert await resource.list(entity_id="76123456-7") == [{"id": "e1"}]
@@ -288,15 +238,9 @@ class TestAsyncMaterialEventsResource:
         respx_mock.get(
             "/material-events",
             params={"since": "2026-01-01T00:00:00+00:00"},
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "iso"}], "next": None}
-            )
-        )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "iso"}], "next": None}))
         resource = AsyncMaterialEventsResource(async_client)
-        result = await resource.list(
-            since=datetime(2026, 1, 1, tzinfo=timezone.utc)
-        )
+        result = await resource.list(since=datetime(2026, 1, 1, tzinfo=timezone.utc))
         assert result == [{"id": "iso"}]
 
     async def test_async_list_with_until_and_limit(
@@ -305,11 +249,7 @@ class TestAsyncMaterialEventsResource:
         respx_mock.get(
             "/material-events",
             params={"until": "2026-04-01T00:00:00Z", "limit": "3"},
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "ul"}], "next": None}
-            )
-        )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "ul"}], "next": None}))
         resource = AsyncMaterialEventsResource(async_client)
         result = await resource.list(until="2026-04-01T00:00:00Z", limit=3)
         assert result == [{"id": "ul"}]
@@ -327,14 +267,10 @@ class TestAsyncMaterialEventsResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/material-events", params={"cursor": "tok2"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 2}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 2}], "next": None})
         )
         respx_mock.get("/material-events", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 1}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 1}], "next": "tok2"})
         )
         resource = AsyncMaterialEventsResource(async_client)
         collected: list[dict[str, Any]] = []
@@ -348,17 +284,9 @@ class TestAsyncMaterialEventsResource:
         respx_mock.get(
             "/material-events",
             params={"entity_id": "76123456-7", "cursor": "n2"},
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
-        )
-        respx_mock.get(
-            "/material-events", params={"entity_id": "76123456-7"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+        ).mock(return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None}))
+        respx_mock.get("/material-events", params={"entity_id": "76123456-7"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = AsyncMaterialEventsResource(async_client)
         collected: list[dict[str, Any]] = []
@@ -370,24 +298,14 @@ class TestAsyncMaterialEventsResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         iso = "2026-01-01T00:00:00+00:00"
-        respx_mock.get(
-            "/material-events", params={"since": iso, "cursor": "c2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p2"}], "next": None}
-            )
+        respx_mock.get("/material-events", params={"since": iso, "cursor": "c2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "p2"}], "next": None})
         )
-        respx_mock.get(
-            "/material-events", params={"since": iso}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p1"}], "next": "c2"}
-            )
+        respx_mock.get("/material-events", params={"since": iso}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "p1"}], "next": "c2"})
         )
         resource = AsyncMaterialEventsResource(async_client)
         collected: list[dict[str, Any]] = []
-        async for item in resource.iter_all(
-            since=datetime(2026, 1, 1, tzinfo=timezone.utc)
-        ):
+        async for item in resource.iter_all(since=datetime(2026, 1, 1, tzinfo=timezone.utc)):
             collected.append(item)
         assert collected == [{"id": "p1"}, {"id": "p2"}]

--- a/tests/resources/test_material_events.py
+++ b/tests/resources/test_material_events.py
@@ -1,0 +1,393 @@
+"""TDD tests for :mod:`cerberus_compliance.resources.material_events`.
+
+Covers :class:`MaterialEventsResource` and its async mirror: list/get/iter_all
+surface, datetime->ISO coercion on ``since`` / ``until`` filters, cursor
+pagination forwarding, and propagation of API errors including 429 rate
+limits.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError, RateLimitError
+from cerberus_compliance.resources.material_events import (
+    AsyncMaterialEventsResource,
+    MaterialEventsResource,
+)
+from cerberus_compliance.retry import RetryConfig
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncMaterialEventsResource:
+    def test_list_no_params(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/material-events").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "evt1"}, {"id": "evt2"}], "next": None},
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        assert resource.list() == [{"id": "evt1"}, {"id": "evt2"}]
+        assert route.called
+
+    def test_list_with_entity_id(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events", params={"entity_id": "76123456-7"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evt1"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        assert resource.list(entity_id="76123456-7") == [{"id": "evt1"}]
+        assert route.called
+
+    def test_list_with_since_string(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events", params={"since": "2026-01-01T00:00:00Z"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evtA"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        assert resource.list(since="2026-01-01T00:00:00Z") == [{"id": "evtA"}]
+        assert route.called
+
+    def test_list_with_since_datetime(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events", params={"since": "2026-01-01T00:00:00+00:00"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evtB"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        result = resource.list(since=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        assert result == [{"id": "evtB"}]
+        assert route.called
+
+    def test_list_with_until_datetime(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events", params={"until": "2026-04-01T00:00:00+00:00"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evtC"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        result = resource.list(until=datetime(2026, 4, 1, tzinfo=timezone.utc))
+        assert result == [{"id": "evtC"}]
+        assert route.called
+
+    def test_list_with_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events", params={"limit": "10"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evtD"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        assert resource.list(limit=10) == [{"id": "evtD"}]
+        assert route.called
+
+    def test_list_with_all_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/material-events",
+            params={
+                "entity_id": "76123456-7",
+                "since": "2026-01-01T00:00:00+00:00",
+                "until": "2026-04-01T00:00:00Z",
+                "limit": "50",
+            },
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "evtAll"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        result = resource.list(
+            entity_id="76123456-7",
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            until="2026-04-01T00:00:00Z",
+            limit=50,
+        )
+        assert result == [{"id": "evtAll"}]
+        assert route.called
+
+    def test_get_returns_event(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/material-events/evt_abc").mock(
+            return_value=httpx.Response(
+                200, json={"id": "evt_abc", "headline": "Profit warning"}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        assert resource.get("evt_abc") == {
+            "id": "evt_abc",
+            "headline": "Profit warning",
+        }
+
+    def test_iter_all_no_filters_paginates(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Register the more specific (cursor) route FIRST — respx matches
+        # params as a subset, so ``params={}`` would otherwise swallow the
+        # cursor request.
+        page2 = respx_mock.get(
+            "/material-events", params={"cursor": "tok2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e2"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get("/material-events", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e1"}], "next": "tok2"}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        items = list(resource.iter_all())
+        assert items == [{"id": "e1"}, {"id": "e2"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_forwards_entity_id(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page2 = respx_mock.get(
+            "/material-events",
+            params={"entity_id": "76123456-7", "cursor": "n2"},
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get(
+            "/material-events", params={"entity_id": "76123456-7"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        items = list(resource.iter_all(entity_id="76123456-7"))
+        assert items == [{"id": "a"}, {"id": "b"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_coerces_datetime_filter(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        iso = "2026-01-01T00:00:00+00:00"
+        route = respx_mock.get(
+            "/material-events", params={"since": iso}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "only"}], "next": None}
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        items = list(
+            resource.iter_all(since=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        )
+        assert items == [{"id": "only"}]
+        assert route.called
+
+    def test_get_propagates_404(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/material-events/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "type": "about:blank",
+                    "title": "Not Found",
+                    "status": 404,
+                    "detail": "event missing",
+                },
+            )
+        )
+        resource = MaterialEventsResource(sync_client)
+        with pytest.raises(CerberusAPIError) as exc_info:
+            resource.get("missing")
+        assert exc_info.value.status == 404
+
+    def test_get_propagates_429_as_rate_limit_error(
+        self, api_key: str, base_url: str, respx_mock: respx.MockRouter
+    ) -> None:
+        client = CerberusClient(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=2.0,
+            retry=RetryConfig(max_attempts=1, base_delay_ms=1),
+        )
+        try:
+            respx_mock.get("/material-events/rate-limited").mock(
+                return_value=httpx.Response(
+                    429,
+                    headers={"retry-after": "1"},
+                    json={"title": "Too Many Requests", "status": 429},
+                )
+            )
+            resource = MaterialEventsResource(client)
+            with pytest.raises(RateLimitError):
+                resource.get("rate-limited")
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncMaterialEventsResource:
+    async def test_async_list_returns_data(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/material-events", params={"entity_id": "76123456-7"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "e1"}], "next": None}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        assert await resource.list(entity_id="76123456-7") == [{"id": "e1"}]
+
+    async def test_async_list_coerces_datetime(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/material-events",
+            params={"since": "2026-01-01T00:00:00+00:00"},
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "iso"}], "next": None}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        result = await resource.list(
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
+        assert result == [{"id": "iso"}]
+
+    async def test_async_list_with_until_and_limit(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/material-events",
+            params={"until": "2026-04-01T00:00:00Z", "limit": "3"},
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "ul"}], "next": None}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        result = await resource.list(until="2026-04-01T00:00:00Z", limit=3)
+        assert result == [{"id": "ul"}]
+
+    async def test_async_get_returns_event(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/material-events/evt_xyz").mock(
+            return_value=httpx.Response(200, json={"id": "evt_xyz"})
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        assert await resource.get("evt_xyz") == {"id": "evt_xyz"}
+
+    async def test_async_iter_all_paginates(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/material-events", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 2}], "next": None}
+            )
+        )
+        respx_mock.get("/material-events", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 1}], "next": "tok2"}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            collected.append(item)
+        assert collected == [{"id": 1}, {"id": 2}]
+
+    async def test_async_iter_all_forwards_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/material-events",
+            params={"entity_id": "76123456-7", "cursor": "n2"},
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        respx_mock.get(
+            "/material-events", params={"entity_id": "76123456-7"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(entity_id="76123456-7"):
+            collected.append(item)
+        assert collected == [{"id": "a"}, {"id": "b"}]
+
+    async def test_async_iter_all_coerces_datetime_filter(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        iso = "2026-01-01T00:00:00+00:00"
+        respx_mock.get(
+            "/material-events", params={"since": iso, "cursor": "c2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p2"}], "next": None}
+            )
+        )
+        respx_mock.get(
+            "/material-events", params={"since": iso}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p1"}], "next": "c2"}
+            )
+        )
+        resource = AsyncMaterialEventsResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(
+            since=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        ):
+            collected.append(item)
+        assert collected == [{"id": "p1"}, {"id": "p2"}]

--- a/tests/resources/test_persons.py
+++ b/tests/resources/test_persons.py
@@ -175,6 +175,22 @@ class TestSyncPersonsResource:
         finally:
             client.close()
 
+    # ------------------------------------------------------------------
+    # Path-traversal hardening (OWASP A01)
+    # ------------------------------------------------------------------
+
+    def test_path_traversal_id_is_percent_encoded(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        """User-supplied id_ containing '../' must be percent-encoded, not traversed."""
+        route = respx_mock.get("/persons/..%2Fadmin/regulatory-profile").mock(
+            return_value=httpx.Response(200, json={"pep": False})
+        )
+        resource = PersonsResource(sync_client)
+        result = resource.regulatory_profile("../admin")
+        assert result == {"pep": False}
+        assert route.called
+
 
 # ---------------------------------------------------------------------------
 # Async tests
@@ -251,3 +267,19 @@ class TestAsyncPersonsResource:
         )
         resource = AsyncPersonsResource(async_client)
         assert await resource.list(rut="7890123-4", limit=5) == [{"id": "pZ"}]
+
+    # ------------------------------------------------------------------
+    # Path-traversal hardening (OWASP A01)
+    # ------------------------------------------------------------------
+
+    async def test_path_traversal_id_is_percent_encoded(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        """User-supplied id_ containing '../' must be percent-encoded, not traversed."""
+        route = respx_mock.get("/persons/..%2Fadmin/regulatory-profile").mock(
+            return_value=httpx.Response(200, json={"pep": False})
+        )
+        resource = AsyncPersonsResource(async_client)
+        result = await resource.regulatory_profile("../admin")
+        assert result == {"pep": False}
+        assert route.called

--- a/tests/resources/test_persons.py
+++ b/tests/resources/test_persons.py
@@ -1,0 +1,291 @@
+"""TDD tests for :mod:`cerberus_compliance.resources.persons`.
+
+Covers :class:`PersonsResource` and :class:`AsyncPersonsResource`: the
+``list`` / ``get`` / ``regulatory_profile`` / ``iter_all`` surface,
+cursor pagination, filter forwarding, and propagation of API errors
+(4xx / 429) up the call stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.errors import CerberusAPIError, RateLimitError
+from cerberus_compliance.resources.persons import AsyncPersonsResource, PersonsResource
+from cerberus_compliance.retry import RetryConfig
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncPersonsResource:
+    def test_list_no_params(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/persons").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p1"}, {"id": "p2"}], "next": None}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.list() == [{"id": "p1"}, {"id": "p2"}]
+        assert route.called
+
+    def test_list_with_rut(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "7890123-4"}], "next": None}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.list(rut="7890123-4") == [{"id": "7890123-4"}]
+        assert route.called
+
+    def test_list_with_limit(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/persons", params={"limit": "50"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p9"}], "next": None}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.list(limit=50) == [{"id": "p9"}]
+        assert route.called
+
+    def test_list_with_both_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/persons", params={"rut": "7890123-4", "limit": "10"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "pZ"}], "next": None}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.list(rut="7890123-4", limit=10) == [{"id": "pZ"}]
+        assert route.called
+
+    def test_get_returns_person(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/persons/7890123-4").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "7890123-4",
+                    "name": "Jose Ignacio Concha",
+                    "nationality": "CL",
+                },
+            )
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.get("7890123-4") == {
+            "id": "7890123-4",
+            "name": "Jose Ignacio Concha",
+            "nationality": "CL",
+        }
+
+    def test_regulatory_profile_returns_dict(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        profile = {
+            "pep": True,
+            "score": 42,
+            "watchlists": ["OFAC"],
+            "last_reviewed_at": "2026-04-01T12:00:00Z",
+        }
+        route = respx_mock.get("/persons/7890123-4/regulatory-profile").mock(
+            return_value=httpx.Response(200, json=profile)
+        )
+        resource = PersonsResource(sync_client)
+        assert resource.regulatory_profile("7890123-4") == profile
+        assert route.called
+
+    def test_iter_all_no_filters_paginates(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Specific (cursor) route registered FIRST so the dispatcher
+        # hits it before the bare subset match.
+        page2 = respx_mock.get("/persons", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p2"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get("/persons", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p1"}], "next": "tok2"}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        items = list(resource.iter_all())
+        assert items == [{"id": "p1"}, {"id": "p2"}]
+        assert page1.called
+        assert page2.called
+
+    def test_iter_all_forwards_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page2 = respx_mock.get(
+            "/persons", params={"rut": "7890123-4", "cursor": "n2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        page1 = respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = PersonsResource(sync_client)
+        items = list(resource.iter_all(rut="7890123-4"))
+        assert items == [{"id": "a"}, {"id": "b"}]
+        assert page1.called
+        assert page2.called
+
+    def test_get_propagates_404(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/persons/missing").mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "type": "about:blank",
+                    "title": "Not Found",
+                    "status": 404,
+                    "detail": "Person missing",
+                },
+            )
+        )
+        resource = PersonsResource(sync_client)
+        with pytest.raises(CerberusAPIError) as exc_info:
+            resource.get("missing")
+        assert exc_info.value.status == 404
+
+    def test_get_propagates_429_as_rate_limit_error(
+        self, api_key: str, base_url: str, respx_mock: respx.MockRouter
+    ) -> None:
+        # Fresh client with no retries so the 429 surfaces without delay.
+        client = CerberusClient(
+            api_key=api_key,
+            base_url=base_url,
+            retry=RetryConfig(max_attempts=1, base_delay_ms=1),
+        )
+        try:
+            respx_mock.get("/persons/rate-limited").mock(
+                return_value=httpx.Response(
+                    429,
+                    headers={"retry-after": "1"},
+                    json={"title": "Too Many Requests", "status": 429},
+                )
+            )
+            resource = PersonsResource(client)
+            with pytest.raises(RateLimitError):
+                resource.get("rate-limited")
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncPersonsResource:
+    async def test_async_list_returns_data(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/persons").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "p0"}], "next": None}
+            )
+        )
+        resource = AsyncPersonsResource(async_client)
+        assert await resource.list() == [{"id": "p0"}]
+
+    async def test_async_get_returns_person(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/persons/7890123-4").mock(
+            return_value=httpx.Response(
+                200, json={"id": "7890123-4", "name": "Jane Roe"}
+            )
+        )
+        resource = AsyncPersonsResource(async_client)
+        assert await resource.get("7890123-4") == {
+            "id": "7890123-4",
+            "name": "Jane Roe",
+        }
+
+    async def test_async_regulatory_profile_returns_dict(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        profile = {"pep": False, "score": 7, "watchlists": []}
+        respx_mock.get("/persons/7890123-4/regulatory-profile").mock(
+            return_value=httpx.Response(200, json=profile)
+        )
+        resource = AsyncPersonsResource(async_client)
+        assert await resource.regulatory_profile("7890123-4") == profile
+
+    async def test_async_iter_all_paginates(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/persons", params={"cursor": "tok2"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 2}], "next": None}
+            )
+        )
+        respx_mock.get("/persons", params={}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": 1}], "next": "tok2"}
+            )
+        )
+        resource = AsyncPersonsResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all():
+            collected.append(item)
+        assert collected == [{"id": 1}, {"id": 2}]
+
+    async def test_async_iter_all_forwards_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/persons", params={"rut": "7890123-4", "cursor": "n2"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "b"}], "next": None}
+            )
+        )
+        respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "a"}], "next": "n2"}
+            )
+        )
+        resource = AsyncPersonsResource(async_client)
+        collected: list[dict[str, Any]] = []
+        async for item in resource.iter_all(rut="7890123-4"):
+            collected.append(item)
+        assert collected == [{"id": "a"}, {"id": "b"}]
+
+    async def test_async_list_with_filters(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(
+            "/persons", params={"rut": "7890123-4", "limit": "5"}
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "pZ"}], "next": None}
+            )
+        )
+        resource = AsyncPersonsResource(async_client)
+        assert await resource.list(rut="7890123-4", limit=5) == [{"id": "pZ"}]

--- a/tests/resources/test_persons.py
+++ b/tests/resources/test_persons.py
@@ -37,13 +37,9 @@ class TestSyncPersonsResource:
         assert resource.list() == [{"id": "p1"}, {"id": "p2"}]
         assert route.called
 
-    def test_list_with_rut(
-        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
-    ) -> None:
+    def test_list_with_rut(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
         route = respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "7890123-4"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "7890123-4"}], "next": None})
         )
         resource = PersonsResource(sync_client)
         assert resource.list(rut="7890123-4") == [{"id": "7890123-4"}]
@@ -53,9 +49,7 @@ class TestSyncPersonsResource:
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         route = respx_mock.get("/persons", params={"limit": "50"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p9"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "p9"}], "next": None})
         )
         resource = PersonsResource(sync_client)
         assert resource.list(limit=50) == [{"id": "p9"}]
@@ -64,12 +58,8 @@ class TestSyncPersonsResource:
     def test_list_with_both_filters(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        route = respx_mock.get(
-            "/persons", params={"rut": "7890123-4", "limit": "10"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "pZ"}], "next": None}
-            )
+        route = respx_mock.get("/persons", params={"rut": "7890123-4", "limit": "10"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "pZ"}], "next": None})
         )
         resource = PersonsResource(sync_client)
         assert resource.list(rut="7890123-4", limit=10) == [{"id": "pZ"}]
@@ -117,14 +107,10 @@ class TestSyncPersonsResource:
         # Specific (cursor) route registered FIRST so the dispatcher
         # hits it before the bare subset match.
         page2 = respx_mock.get("/persons", params={"cursor": "tok2"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p2"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "p2"}], "next": None})
         )
         page1 = respx_mock.get("/persons", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p1"}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "p1"}], "next": "tok2"})
         )
         resource = PersonsResource(sync_client)
         items = list(resource.iter_all())
@@ -135,17 +121,11 @@ class TestSyncPersonsResource:
     def test_iter_all_forwards_filters(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        page2 = respx_mock.get(
-            "/persons", params={"rut": "7890123-4", "cursor": "n2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
+        page2 = respx_mock.get("/persons", params={"rut": "7890123-4", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
         )
         page1 = respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = PersonsResource(sync_client)
         items = list(resource.iter_all(rut="7890123-4"))
@@ -206,9 +186,7 @@ class TestAsyncPersonsResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/persons").mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "p0"}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "p0"}], "next": None})
         )
         resource = AsyncPersonsResource(async_client)
         assert await resource.list() == [{"id": "p0"}]
@@ -217,9 +195,7 @@ class TestAsyncPersonsResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/persons/7890123-4").mock(
-            return_value=httpx.Response(
-                200, json={"id": "7890123-4", "name": "Jane Roe"}
-            )
+            return_value=httpx.Response(200, json={"id": "7890123-4", "name": "Jane Roe"})
         )
         resource = AsyncPersonsResource(async_client)
         assert await resource.get("7890123-4") == {
@@ -241,14 +217,10 @@ class TestAsyncPersonsResource:
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
         respx_mock.get("/persons", params={"cursor": "tok2"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 2}], "next": None}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 2}], "next": None})
         )
         respx_mock.get("/persons", params={}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": 1}], "next": "tok2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": 1}], "next": "tok2"})
         )
         resource = AsyncPersonsResource(async_client)
         collected: list[dict[str, Any]] = []
@@ -259,17 +231,11 @@ class TestAsyncPersonsResource:
     async def test_async_iter_all_forwards_filters(
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.get(
-            "/persons", params={"rut": "7890123-4", "cursor": "n2"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "b"}], "next": None}
-            )
+        respx_mock.get("/persons", params={"rut": "7890123-4", "cursor": "n2"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "b"}], "next": None})
         )
         respx_mock.get("/persons", params={"rut": "7890123-4"}).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "a"}], "next": "n2"}
-            )
+            return_value=httpx.Response(200, json={"data": [{"id": "a"}], "next": "n2"})
         )
         resource = AsyncPersonsResource(async_client)
         collected: list[dict[str, Any]] = []
@@ -280,12 +246,8 @@ class TestAsyncPersonsResource:
     async def test_async_list_with_filters(
         self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.get(
-            "/persons", params={"rut": "7890123-4", "limit": "5"}
-        ).mock(
-            return_value=httpx.Response(
-                200, json={"data": [{"id": "pZ"}], "next": None}
-            )
+        respx_mock.get("/persons", params={"rut": "7890123-4", "limit": "5"}).mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "pZ"}], "next": None})
         )
         resource = AsyncPersonsResource(async_client)
         assert await resource.list(rut="7890123-4", limit=5) == [{"id": "pZ"}]


### PR DESCRIPTION
## Summary

Implements Instance B scope from `docs/superpowers/plans/2026-04-22-overhaul-p4-sdks.md`: three new sub-resources of the `cerberus-compliance` Python SDK (entities, persons, material_events) with strict TDD, plus append-only wire-up into `CerberusClient` / `AsyncCerberusClient`.

Foundation (Instance A) at `e4fedb4`; handoff at `1a1cacd`.

- `cerberus_compliance/resources/entities.py` — sync + async, methods: `list/get/material_events/sanctions/directors/regulations/iter_all`.
- `cerberus_compliance/resources/persons.py` — sync + async, methods: `list/get/regulatory_profile/iter_all`.
- `cerberus_compliance/resources/material_events.py` — sync + async, methods: `list/get/iter_all`; `since`/`until` accept `str` or tz-aware `datetime` (coerced to ISO-8601 via `.isoformat()`).
- `cerberus_compliance/resources/__init__.py` — re-exports the 6 resource classes + `BaseResource`/`AsyncBaseResource`.
- `cerberus_compliance/client.py` — attribute wiring inserted **above** the `# INSERT RESOURCES HERE` marker in both `__init__` bodies; marker preserved (present exactly twice), so Instance C rebases trivially.

## Security fix (cerberus-auditor pass)

- `fix(security): percent-encode id_ in sub-resource path construction` (`dfc0b7b`): `httpx` resolves `../` in URL merging, so a caller-supplied `id_ = "../admin"` would cause `/entities/../admin/sanctions` to resolve to `/admin/sanctions` (OWASP A01 — Broken Access Control). Applied `urllib.parse.quote(id_, safe="")` to every direct f-string path construction in `entities.py` and `persons.py`. `material_events.py` is unaffected (delegates to `_base._get` only). Four regression tests added (sync + async per resource).

## Gates (all green on `27f3b36`)

- `pytest -q` — **238 passed**
- `ruff check .` — clean
- `ruff format --check .` — 22 files formatted
- `mypy --strict cerberus_compliance/` — no issues, 10 source files
- Overall branch coverage: **99.79%** (gate 90%)
- Per-file coverage on B's deliverables (via isolated rcfile, bypassing the foundation-stub omits for C's files): `entities.py` **100%**, `persons.py` **100%**, `material_events.py` **100%**, `resources/__init__.py` **100%**, `_base.py` 97%.

## Scope compliance

- Touched only: the 3 new resource files + the 3 matching test files + append-only edits to `client.py` and `resources/__init__.py`.
- `pyproject.toml` left untouched (explicitly out of B's scope — the coverage `omit` list there still excludes Instance C's files as a temporary stub; C's PR will remove its own three entries).
- `cerberus_compliance/{auth,retry,errors,_base}.py` untouched.
- `# INSERT RESOURCES HERE` marker preserved at lines 121 and 267 of `client.py`.
- No force pushes, no `--no-verify`.

## Test plan

- [ ] CI matrix (Python 3.10 / 3.11 / 3.12) passes.
- [ ] `cerberus-auditor` approves (already ran locally → one security fix applied, now clean).
- [ ] Instance C's PR (`feat/resources-2`) rebases cleanly on top of this one — the marker is intact in both `__init__` bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)