### PR TITLE
examples(p5): KYB quickstart on typed resources

### DIFF
--- a/examples/kyb_quickstart.py
+++ b/examples/kyb_quickstart.py
@@ -21,11 +21,10 @@ Optional flags ``--base-url`` and ``--api-key`` override the defaults for
 staging / local runs. Install ``rich`` (``pip install rich``) for prettier
 output; plain text is used automatically when ``rich`` is unavailable.
 
-This example targets the foundation-only surface of the SDK (Instance A).
-Once ``feat/resources-1`` (Instance B) lands with typed sub-resource
-accessors, the ``client._request`` calls below should be migrated to
-``client.entities.get(...)``, ``client.entities.material_events.list(...)``,
-etc. — see the ``TODO(#P4-B-merge)`` markers.
+Uses the typed resource accessors introduced with ``feat/resources-1``:
+``client.entities.list(rut=...)``, ``client.material_events.list(...)``,
+``client.sanctions.list(...)``, ``client.entities.directors(...)``, and
+``client.entities.regulations(...)``. No low-level ``_request`` fallbacks.
 """
 
 from __future__ import annotations
@@ -89,16 +88,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 # --------------------------------------------------------------------------- #
-# API calls (low-level: use _request until Instance B merges)                 #
+# API calls (typed resource accessors from feat/resources-1)                  #
 # --------------------------------------------------------------------------- #
-
-
-def _unwrap_list(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract a ``list[dict]`` from a ``{"data": [...]}`` list envelope."""
-    data = payload.get("data", [])
-    if not isinstance(data, list):
-        return []
-    return [item for item in data if isinstance(item, dict)]
 
 
 def resolve_entity(client: CerberusClient, rut: str) -> dict[str, Any] | None:
@@ -106,54 +97,28 @@ def resolve_entity(client: CerberusClient, rut: str) -> dict[str, Any] | None:
 
     Returns ``None`` when no entity is found.
     """
-    # TODO(#P4-B-merge): switch to client.entities.get(rut=...) once feat/resources-1 lands.
-    payload = client._request(
-        "GET",
-        "/entities",
-        params={"rut": rut, "limit": 1},
-    )
-    entities = _unwrap_list(payload)
+    entities = client.entities.list(rut=rut, limit=1)
     return entities[0] if entities else None
 
 
 def list_material_events(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
     """Return the five most recent material/essential facts for an entity."""
-    # TODO(#P4-B-merge): switch to client.entities.material_events.list(...) once
-    # feat/resources-1 lands.
-    payload = client._request(
-        "GET",
-        f"/entities/{entity_id}/material_events",
-        params={"limit": 5},
-    )
-    return _unwrap_list(payload)
+    return client.material_events.list(entity_id=entity_id, limit=5)
 
 
 def list_active_sanctions(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
     """Return the entity's currently active sanctions."""
-    # TODO(#P4-B-merge): switch to client.entities.sanctions.list(active=True) once
-    # feat/resources-1 lands.
-    payload = client._request(
-        "GET",
-        f"/entities/{entity_id}/sanctions",
-        params={"active": "true"},
-    )
-    return _unwrap_list(payload)
+    return client.sanctions.list(target_id=entity_id, active=True)
 
 
 def list_directors(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
     """Return the entity's directors on record."""
-    # TODO(#P4-B-merge): switch to client.entities.directors.list(...) once
-    # feat/resources-1 lands.
-    payload = client._request("GET", f"/entities/{entity_id}/directors")
-    return _unwrap_list(payload)
+    return client.entities.directors(entity_id)
 
 
 def fetch_regulations(client: CerberusClient, entity_id: str) -> list[dict[str, Any]]:
     """Return the entity's regulatory profile (regulator, license, status)."""
-    # TODO(#P4-B-merge): switch to client.entities.regulations.list(...) once
-    # feat/resources-1 lands.
-    payload = client._request("GET", f"/entities/{entity_id}/regulations")
-    return _unwrap_list(payload)
+    return client.entities.regulations(entity_id)
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/notebooks/01-kyb-quickstart.ipynb
+++ b/examples/notebooks/01-kyb-quickstart.ipynb
@@ -116,21 +116,7 @@
    "cell_type": "markdown",
    "id": "14cfe482",
    "metadata": {},
-   "source": [
-    "## Step 3 — Resolve the entity\n",
-    "\n",
-    "Entities are queried by RUT through `GET /entities?rut=...`. The response\n",
-    "is a standard list envelope:\n",
-    "\n",
-    "```json\n",
-    "{\"data\": [ {\"id\": \"...\", \"legal_name\": \"...\", ...} ], \"next\": null}\n",
-    "```\n",
-    "\n",
-    "For this quickstart we use the low-level `client._request(...)` escape\n",
-    "hatch, which is available today. Once the resources PR lands, the more\n",
-    "ergonomic `client.entities.get(rut=rut)` will replace every `_request`\n",
-    "call in this notebook."
-   ]
+   "source": "## Step 3 — Resolve the entity\n\nEntities are queried by RUT through the typed `client.entities.list(rut=...)`\naccessor. The underlying envelope is a `{\"data\": [...]}` list, but the SDK\nunwraps it and returns a plain `list[dict]` so you can index directly.\n\nThis notebook uses the typed resource accessors introduced in\n`feat/resources-1`: `client.entities.list(rut=...)`,\n`client.material_events.list(entity_id=...)`, `client.sanctions.list(...)`,\nand the nested `client.entities.directors(...)` / `.regulations(...)`\nhelpers. No low-level `_request` fallbacks needed."
   },
   {
    "cell_type": "code",
@@ -138,13 +124,7 @@
    "id": "2b4c129a",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# TODO(#P4-B-merge): switch to client.entities.get(rut=rut) once feat/resources-1 lands.\n",
-    "response = client._request(\"GET\", \"/entities\", params={\"rut\": rut, \"limit\": 1})\n",
-    "entities = response.get(\"data\", [])\n",
-    "entity = entities[0] if entities else None\n",
-    "entity"
-   ]
+   "source": "entities = client.entities.list(rut=rut, limit=1)\nentity = entities[0] if entities else None\nentity"
   },
   {
    "cell_type": "markdown",
@@ -169,16 +149,7 @@
    "id": "90b5694c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# TODO(#P4-B-merge): switch to client.entities.material_events(id=entity[\"id\"], limit=5).\n",
-    "events_resp = client._request(\n",
-    "    \"GET\",\n",
-    "    f\"/entities/{entity['id']}/material_events\",\n",
-    "    params={\"limit\": 5},\n",
-    ")\n",
-    "events = events_resp.get(\"data\", [])\n",
-    "events"
-   ]
+   "source": "events = client.material_events.list(entity_id=entity[\"id\"], limit=5)\nevents"
   },
   {
    "cell_type": "markdown",
@@ -206,16 +177,7 @@
    "id": "0e6279af",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# TODO(#P4-B-merge): switch to client.entities.sanctions(id=entity[\"id\"], active=True).\n",
-    "sanctions_resp = client._request(\n",
-    "    \"GET\",\n",
-    "    f\"/entities/{entity['id']}/sanctions\",\n",
-    "    params={\"active\": \"true\"},\n",
-    ")\n",
-    "sanctions = sanctions_resp.get(\"data\", [])\n",
-    "sanctions"
-   ]
+   "source": "sanctions = client.sanctions.list(target_id=entity[\"id\"], active=True)\nsanctions"
   },
   {
    "cell_type": "markdown",
@@ -243,12 +205,7 @@
    "id": "908b5e3b",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# TODO(#P4-B-merge): switch to client.entities.regulations(id=entity[\"id\"]).\n",
-    "regs_resp = client._request(\"GET\", f\"/entities/{entity['id']}/regulations\")\n",
-    "regulations = regs_resp.get(\"data\", [])\n",
-    "regulations"
-   ]
+   "source": "regulations = client.entities.regulations(entity[\"id\"])\nregulations"
   },
   {
    "cell_type": "markdown",
@@ -293,24 +250,7 @@
    "cell_type": "markdown",
    "id": "747a2316",
    "metadata": {},
-   "source": [
-    "## Clean up\n",
-    "\n",
-    "`CerberusClient` is a context manager. This notebook created one *outside*\n",
-    "a `with` block on purpose — it lets you re-run individual cells without\n",
-    "rebuilding the HTTP session each time, which is great for experimentation.\n",
-    "\n",
-    "In production, prefer the context-manager form so the underlying\n",
-    "connection pool is always released cleanly:\n",
-    "\n",
-    "```python\n",
-    "with CerberusClient() as client:\n",
-    "    response = client._request(\"GET\", \"/entities\", params={\"rut\": rut})\n",
-    "```\n",
-    "\n",
-    "When used outside a `with` block, call `.close()` explicitly before the\n",
-    "kernel shuts down."
-   ]
+   "source": "## Clean up\n\n`CerberusClient` is a context manager. This notebook created one *outside*\na `with` block on purpose — it lets you re-run individual cells without\nrebuilding the HTTP session each time, which is great for experimentation.\n\nIn production, prefer the context-manager form so the underlying\nconnection pool is always released cleanly:\n\n```python\nwith CerberusClient() as client:\n    entities = client.entities.list(rut=rut)\n```\n\nWhen used outside a `with` block, call `.close()` explicitly before the\nkernel shuts down."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Migrates \`examples/kyb_quickstart.py\` and \`examples/notebooks/01-kyb-quickstart.ipynb\` off the low-level \`client._request(...)\` escape hatch onto the typed resource accessors introduced in \`feat/resources-1\`.

Removes the \`TODO(#P4-B-merge)\` markers that were parked awaiting this migration.

## Changes

- \`resolve_entity\` → \`client.entities.list(rut=rut, limit=1)\`
- \`list_material_events\` → \`client.material_events.list(entity_id=..., limit=5)\`
- \`list_active_sanctions\` → \`client.sanctions.list(target_id=..., active=True)\`
- \`list_directors\` → \`client.entities.directors(entity_id)\`
- \`fetch_regulations\` → \`client.entities.regulations(entity_id)\`

Docstrings + markdown prose updated to match. No SDK core changes.

Companion to the P5 KYB Express rollout on [cerberus_compliance#feat/p5-infra](https://github.com/l0rdbarcsacs/cerberus_compliance/pull/new/feat/p5-infra).

## Test plan

- [ ] \`ruff check examples/\` → passing
- [ ] \`mypy examples/kyb_quickstart.py\` → passing
- [ ] Manual smoke: \`CERBERUS_API_KEY=... python examples/kyb_quickstart.py --rut 76.086.428-5\` against staging once available.
- [ ] Notebook renders correctly in JupyterLab (no broken markdown cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)