### PR TITLE
chore(release): bump to 0.2.0rc1 for TestPyPI canary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.2.0"
+version = "0.2.0rc1"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bumps pyproject.toml version from 0.2.0 → 0.2.0rc1
- Required for the v0.2.0-rc1 tag to produce a PEP 440-compliant wheel
- Triggers release.yml on tag:
  - publish-testpypi uploads wheel to TestPyPI
  - verify-testpypi runs canary (install + kyb.get against staging)
  - publish-pypi is gated by !contains(-rc) so does NOT fire on this tag

## Test plan
- [ ] Push merge → no CI triggered by release path until tag is pushed
- [ ] After merge, orchestrator tags v0.2.0-rc1
- [ ] Release.yml fires: publish-testpypi + verify-testpypi both green
- [ ] Stable 0.2.0 bump is a follow-up PR once canary is confirmed