### PR TITLE
chore(release): promote to 0.2.0 stable for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.2.0rc1"
+version = "0.2.0"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
Bumps pyproject.toml 0.2.0rc1 → 0.2.0. Tag v0.2.0 triggers publish-pypi.

rc1 canary was verified green: TestPyPI install + client.kyb.get("96.505.760-9") against staging.

## Test plan
- [ ] Merge
- [ ] Orchestrator tags v0.2.0
- [ ] release.yml publish-pypi uploads to PyPI using env:pypi / PYPI_API_TOKEN
- [ ] pip install cerberus-compliance==0.2.0 from PyPI stable