### PR TITLE
fix(ci): disable coverage gate on integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,7 @@ jobs:
       - name: Smoke against staging
         env:
           CERBERUS_STAGING_KEY: ${{ secrets.CERBERUS_STAGING_KEY }}
-        run: pytest tests/integration/ -q
+        # --no-cov disables the 95% coverage gate from pyproject.toml addopts:
+        # integration tests only exercise live-API paths (~64% cov); the gate
+        # is enforced by the unit-test matrix above, not by this smoke job.
+        run: pytest tests/integration/ -q --no-cov


### PR DESCRIPTION
The integration (live staging) job was failing with 'Required test coverage of 95% not reached. Total coverage: 63.84%'. Root cause: pyproject.toml sets --cov-fail-under=95 in pytest addopts, applied to every pytest invocation. Integration tests only exercise live-API paths so the gate aborts the job even when all 13 tests pass. Fix: add --no-cov to the integration pytest step. Unit-test matrix still enforces 95%.