### PR TITLE
fix(ci): revert upload-artifact to @v7 — v8 does not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: pytest -q
       - name: Upload coverage report (py3.12 only)
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: python -m build
       - name: Validate metadata
         run: twine check dist/*
-      - uses: actions/upload-artifact@v8
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
PR #20 set upload-artifact@v8 but latest is v7. download-artifact@v8 stays (shared backend, compatible). Main CI failing with 'Unable to resolve action'.