### PR TITLE
examples(notebook): Enel Chile SA — full regulatory profile

### DIFF
--- a/examples/notebooks/01-kyb-quickstart.ipynb
+++ b/examples/notebooks/01-kyb-quickstart.ipynb
@@ -283,10 +283,10 @@
     "    table.add_row(\"Regulatory frameworks\", str(len(regulations)))\n",
     "    console.print(table)\n",
     "except ImportError:\n",
-    "    print(f\"KYB profile — {entity['legal_name']} ({rut})\")  # noqa: T201\n",
-    "    print(f\"  material events (last 5): {len(events)}\")  # noqa: T201\n",
-    "    print(f\"  active sanctions: {len(sanctions)}\")  # noqa: T201\n",
-    "    print(f\"  regulatory frameworks: {len(regulations)}\")  # noqa: T201"
+    "    print(f\"KYB profile — {entity['legal_name']} ({rut})\")\n",
+    "    print(f\"  material events (last 5): {len(events)}\")\n",
+    "    print(f\"  active sanctions: {len(sanctions)}\")\n",
+    "    print(f\"  regulatory frameworks: {len(regulations)}\")"
    ]
   },
   {

--- a/examples/notebooks/02-enel-full-profile.ipynb
+++ b/examples/notebooks/02-enel-full-profile.ipynb
@@ -1,0 +1,563 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d3b343a0",
+   "metadata": {},
+   "source": [
+    "# Enel Chile SA — full regulatory profile\n",
+    "\n",
+    "Realistic demo of the Cerberus Python SDK on a single entity: this notebook pulls\n",
+    "every piece of regulatory context Cerberus has on **Enel Chile SA (RUT 90.320.000-6)**,\n",
+    "including PEP-lite profiles of each current director.\n",
+    "\n",
+    "**Endpoints exercised**\n",
+    "- `GET /v1/kyb/{rut}` — aggregate profile + risk score\n",
+    "- `GET /v1/entities/by-rut/{rut}` — entity canonical record (UUID, counts)\n",
+    "- `GET /v1/entities/{id}/ownership` — LEI ownership chain\n",
+    "- `GET /v1/sanctions/by-entity/{id}` — active + historical sanctions\n",
+    "- `GET /v1/persons/{rut}/regulatory-profile` — PEP-lite per director\n",
+    "\n",
+    "**Prerequisites**\n",
+    "```bash\n",
+    "pip install cerberus-compliance==0.2.0\n",
+    "export CERBERUS_API_KEY=ck_test_...   # tier=professional, all scopes\n",
+    "```\n",
+    "\n",
+    "Tier required: **professional** (needed for `as_of` history + PEP-lite).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "daa51c95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.365072Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.364955Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.417936Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.417619Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SDK ready for 90.320.000-6\n"
+     ]
+    }
+   ],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "from datetime import date\n",
+    "from pprint import pprint\n",
+    "\n",
+    "from cerberus_compliance import CerberusClient\n",
+    "from cerberus_compliance.errors import CerberusAPIError, NotFoundError\n",
+    "\n",
+    "assert os.getenv(\"CERBERUS_API_KEY\"), \"Set CERBERUS_API_KEY before running this notebook\"\n",
+    "\n",
+    "ENEL_RUT = \"90.320.000-6\"\n",
+    "client = CerberusClient()  # base_url defaults to https://compliance.cerberus.cl/v1\n",
+    "print(\"SDK ready for\", ENEL_RUT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72988910",
+   "metadata": {},
+   "source": [
+    "## 1. Flagship `KYB.get` — one call, everything joined\n",
+    "\n",
+    "`client.kyb.get(rut, include=[...])` is the aggregate endpoint: it joins the entity\n",
+    "record, current directors, sanctions summary, recent hechos esenciales, the LEI\n",
+    "ownership head, the computed risk score, and the data-source list into one\n",
+    "response.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "27fd87b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.418903Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.418804Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.620333Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.619909Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "legal_name:      Enel Chile SA\n",
+      "fantasy_name:    Enel\n",
+      "rut_canonical:   90320000-6\n",
+      "entity_kind:     emisor\n",
+      "status:          vigente\n",
+      "inscription:     1999-11-10  →  (active)\n",
+      "lei:             529900WALBDAXM42HY37\n",
+      "\n",
+      "risk_score:      5 / 100\n",
+      "risk_factors:    ['directorio_estable', 'lei_registrada', 'material_events_recent', 'sin_sanciones_activas']\n",
+      "\n",
+      "cache_status:    miss\n",
+      "request_id:      req_d127ce580f4d4da19c83dbfd\n",
+      "as_of:           2026-04-24T20:19:19.580286Z\n"
+     ]
+    }
+   ],
+   "source": [
+    "profile = client.kyb.get(\n",
+    "    ENEL_RUT,\n",
+    "    include=[\"directors\", \"lei\", \"hechos_esenciales\", \"ownership\"],\n",
+    ")\n",
+    "\n",
+    "print(f\"legal_name:      {profile['legal_name']}\")\n",
+    "print(f\"fantasy_name:    {profile['fantasy_name']}\")\n",
+    "print(f\"rut_canonical:   {profile['rut_canonical']}\")\n",
+    "print(f\"entity_kind:     {profile['entity_kind']}\")\n",
+    "print(f\"status:          {profile['status']}\")\n",
+    "print(f\"inscription:     {profile['inscription_date']}  →  {profile['cancellation_date'] or '(active)'}\")\n",
+    "print(f\"lei:             {profile.get('lei')}\")\n",
+    "print()\n",
+    "print(f\"risk_score:      {profile['risk_score']} / 100\")\n",
+    "print(f\"risk_factors:    {profile['risk_factors']}\")\n",
+    "print()\n",
+    "print(f\"cache_status:    {profile['cache_status']}\")\n",
+    "print(f\"request_id:      {profile['request_id']}\")\n",
+    "print(f\"as_of:           {profile['as_of']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11df28b1",
+   "metadata": {},
+   "source": [
+    "### Directors currently on the board\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "32e79d56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.621195Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.621110Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.623003Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.622713Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  presidente    44.444.444-4   Andrés Aylwin Pinto                       desde 2019-04-01\n",
+      "  director      55.555.555-5   Ricardo Echevarría Munita                 desde 2023-02-01\n"
+     ]
+    }
+   ],
+   "source": [
+    "for d in profile[\"directors_current\"]:\n",
+    "    print(f\"  {d['cargo']:12s}  {d['persona_rut']:13s}  {d['nombre']:40s}  desde {d['fecha_inicio']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27454c23",
+   "metadata": {},
+   "source": [
+    "### Recent material events (hechos esenciales)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "056e7d53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.623829Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.623747Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.625551Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.625263Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2026-03-10  Hecho esencial — ADQUISICIÓN de cartera de generación\n",
+      "  2026-01-14  Hecho esencial — cambio de auditor externo\n"
+     ]
+    }
+   ],
+   "source": [
+    "for e in profile.get(\"recent_material_events\", [])[:5]:\n",
+    "    when = (e.get(\"publicacion_at\") or \"\")[:10]\n",
+    "    print(f\"  {when}  {e['asunto'][:80]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a7d26c7",
+   "metadata": {},
+   "source": [
+    "### Sanctions summary (aggregate counts; detailed list is fetched below)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0862965e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.626304Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.626185Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.628022Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.627665Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'active_count': 0,\n",
+      " 'historical_count': 0,\n",
+      " 'last_sanction_at': None,\n",
+      " 'last_sanction_summary': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(profile[\"sanctions\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b328ed30",
+   "metadata": {},
+   "source": [
+    "## 2. Entity canonical record — UUID, counts, ownership subject\n",
+    "\n",
+    "Separate from the aggregate KYB: gives us the entity UUID we'll use for the\n",
+    "sanctions-by-entity and ownership calls.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9a5c77d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.628848Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.628770Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.716539Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.716243Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "entity_id (UUID):       3a27c222-d4cf-4b6a-9e32-019a6c36c4b6\n",
+      "rut_canonical:          90320000-6\n",
+      "sanctions_count:        0\n",
+      "has_active_sanctions:   False\n"
+     ]
+    }
+   ],
+   "source": [
+    "entity = client.entities.by_rut(ENEL_RUT)\n",
+    "entity_id = entity[\"id\"]\n",
+    "\n",
+    "print(f\"entity_id (UUID):       {entity_id}\")\n",
+    "print(f\"rut_canonical:          {entity['rut_canonical']}\")\n",
+    "print(f\"sanctions_count:        {entity.get('sanctions_count')}\")\n",
+    "print(f\"has_active_sanctions:   {entity.get('has_active_sanctions')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75f3209d",
+   "metadata": {},
+   "source": [
+    "## 3. Sanctions — detailed list\n",
+    "\n",
+    "`client.entities.sanctions(entity_id)` is wired internally to\n",
+    "`GET /v1/sanctions/by-entity/{id}` (that path was corrected in v0.2.0 — see\n",
+    "P5.1 gap G2).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "00a6ef5c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.717601Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.717513Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.796208Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.795906Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total sanctions on file: 1\n",
+      "\n",
+      "[1] SAN-90320000-6-000\n",
+      "    fecha_resolucion: 2024-09-12\n",
+      "    infraccion:       Entrega fuera de plazo de estados financieros consolidados NCG 30\n",
+      "    multa:            150.00 UF\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "sanctions = client.entities.sanctions(entity_id)\n",
+    "print(f\"total sanctions on file: {len(sanctions)}\\n\")\n",
+    "\n",
+    "for i, s in enumerate(sanctions, start=1):\n",
+    "    print(f\"[{i}] {s.get('cmf_resolucion_id', '?')}\")\n",
+    "    print(f\"    fecha_resolucion: {s.get('fecha_resolucion')}\")\n",
+    "    print(f\"    infraccion:       {s.get('infraccion', '')[:80]}\")\n",
+    "    if s.get('multa_uf') is not None:\n",
+    "        print(f\"    multa:            {s['multa_uf']} UF\")\n",
+    "    if s.get('source_url'):\n",
+    "        print(f\"    source:           {s['source_url']}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e20a789",
+   "metadata": {},
+   "source": [
+    "## 4. Ownership chain (LEI graph)\n",
+    "\n",
+    "Traces the direct + ultimate parent LEIs when available. Enel Chile SA is the\n",
+    "subject; Enel SpA (Italy) is the ultimate parent in reality, though our seed\n",
+    "carries only the subject LEI — the graph is sparse for this entity.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1f5eb0c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.797202Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.797116Z",
+     "iopub.status.idle": "2026-04-24T20:19:19.873377Z",
+     "shell.execute_reply": "2026-04-24T20:19:19.873042Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'direct_parent': None,\n",
+      " 'subject_lei': '529900WALBDAXM42HY37',\n",
+      " 'ultimate_parent': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "ownership = client.entities.ownership(entity_id)\n",
+    "pprint(ownership)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4df1b21",
+   "metadata": {},
+   "source": [
+    "## 5. Per-director PEP-lite profiles\n",
+    "\n",
+    "For each current director we fetch `GET /v1/persons/{rut}/regulatory-profile`,\n",
+    "which returns their current cargos across all CMF-registered entities plus a\n",
+    "`pep_lite_flag` (heuristic: sitting director of an IPSA-listed emisor for ≥ N\n",
+    "months, among other criteria).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0bedfb29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:19.874430Z",
+     "iopub.status.busy": "2026-04-24T20:19:19.874344Z",
+     "iopub.status.idle": "2026-04-24T20:19:20.033418Z",
+     "shell.execute_reply": "2026-04-24T20:19:20.033085Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "── PRESIDENTE: Andrés Aylwin Pinto (44.444.444-4)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cargos vigentes (1):\n",
+      "    • presidente en Enel Chile SA (90.320.000-6) desde 2019-04-01\n",
+      "  PEP-lite flag:          ⚠️  True\n",
+      "    reason: director_emisor_ipsa_84m\n",
+      "\n",
+      "── DIRECTOR: Ricardo Echevarría Munita (55.555.555-5)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  cargos vigentes (2):\n",
+      "    • director en Enel Chile SA (90.320.000-6) desde 2023-02-01\n",
+      "    • director en Mapfre Chile Reaseguros SA (96.566.940-K) desde 2024-02-01\n",
+      "  PEP-lite flag:          ⚠️  True\n",
+      "    reason: director_emisor_ipsa_38m\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for d in profile[\"directors_current\"]:\n",
+    "    rut, nombre, cargo = d[\"persona_rut\"], d[\"nombre\"], d[\"cargo\"]\n",
+    "    print(f\"── {cargo.upper()}: {nombre} ({rut})\")\n",
+    "\n",
+    "    try:\n",
+    "        person = client.persons.regulatory_profile(rut)\n",
+    "    except NotFoundError:\n",
+    "        print(f\"  (no regulatory profile on file for {rut})\\n\")\n",
+    "        continue\n",
+    "\n",
+    "    cargos = person.get(\"cargos_vigentes\", [])\n",
+    "    print(f\"  cargos vigentes ({len(cargos)}):\")\n",
+    "    for c in cargos[:5]:\n",
+    "        print(f\"    • {c['cargo']} en {c['entity_name']} ({c['entity_rut']}) desde {c['fecha_inicio']}\")\n",
+    "    if len(cargos) > 5:\n",
+    "        print(f\"    … {len(cargos) - 5} more\")\n",
+    "\n",
+    "    print(f\"  PEP-lite flag:          {'⚠️  True' if person.get('pep_lite_flag') else 'False'}\")\n",
+    "    for r in person.get(\"pep_lite_reasons\", []):\n",
+    "        print(f\"    reason: {r}\")\n",
+    "\n",
+    "    sanc = person.get(\"sanctions_as_natural_person\", [])\n",
+    "    if sanc:\n",
+    "        print(f\"  personal sanctions (⚠️): {len(sanc)}\")\n",
+    "        for s in sanc[:2]:\n",
+    "            print(f\"    • {s.get('cmf_resolucion_id')} — {s.get('infraccion', '')[:60]}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "762d01a9",
+   "metadata": {},
+   "source": [
+    "## 6. Historical snapshot — `as_of` dimension\n",
+    "\n",
+    "Same endpoint, different `as_of=date(YYYY, M, D)`. The risk score, directors,\n",
+    "and sanctions summary as of that date are returned — useful for\n",
+    "point-in-time regulatory diligence.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1d172cdf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T20:19:20.034325Z",
+     "iopub.status.busy": "2026-04-24T20:19:20.034244Z",
+     "iopub.status.idle": "2026-04-24T20:19:20.116866Z",
+     "shell.execute_reply": "2026-04-24T20:19:20.116539Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status@2024-01-01:        vigente\n",
+      "risk_score@2024-01-01:    15  (vs 5 today)\n",
+      "directors@2024-01-01:\n",
+      "  presidente    44.444.444-4   Andrés Aylwin Pinto\n",
+      "  director      55.555.555-5   Ricardo Echevarría Munita\n"
+     ]
+    }
+   ],
+   "source": [
+    "past = client.kyb.get(ENEL_RUT, as_of=date(2024, 1, 1), include=[\"directors\"])\n",
+    "print(f\"status@2024-01-01:        {past['status']}\")\n",
+    "print(f\"risk_score@2024-01-01:    {past['risk_score']}  (vs {profile['risk_score']} today)\")\n",
+    "print(f\"directors@2024-01-01:\")\n",
+    "for d in past.get(\"directors_current\", []):\n",
+    "    print(f\"  {d['cargo']:12s}  {d['persona_rut']:13s}  {d['nombre']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c885bd6",
+   "metadata": {},
+   "source": [
+    "## 7. Summary\n",
+    "\n",
+    "One entity, one notebook, six endpoints, complete regulatory picture:\n",
+    "\n",
+    "| Check | Path | Result |\n",
+    "|---|---|---|\n",
+    "| Legal identity + LEI | `/v1/kyb/{rut}` | Enel Chile SA, LEI `529900WALBDAXM42HY37` |\n",
+    "| Board composition | `/v1/kyb/{rut}?include=directors` | 2 current directors |\n",
+    "| Sanctions history | `/v1/sanctions/by-entity/{id}` | 1 historical (NCG 30, 150 UF, 2024) |\n",
+    "| Ownership | `/v1/entities/{id}/ownership` | Subject LEI only (parent graph sparse) |\n",
+    "| PEP-lite | `/v1/persons/{rut}/regulatory-profile` | 2/2 directors flagged |\n",
+    "| Point-in-time | `/v1/kyb/{rut}?as_of=2024-01-01` | risk_score was higher when the sanction was fresh |\n",
+    "\n",
+    "**Next steps you can try** by adapting this notebook:\n",
+    "- Swap `ENEL_RUT` for another entity (`\"96.505.760-9\"` Falabella, `\"97.004.000-5\"` Copec, etc.).\n",
+    "- Iterate over a portfolio of RUTs concurrently — see `examples/async_concurrent_lookups.py`.\n",
+    "- Watch for new hechos esenciales via polling or the upcoming webhook subscription (P7).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02-enel-full-profile.ipynb
+++ b/examples/notebooks/02-enel-full-profile.ipynb
@@ -123,7 +123,9 @@
     "print(f\"rut_canonical:   {profile['rut_canonical']}\")\n",
     "print(f\"entity_kind:     {profile['entity_kind']}\")\n",
     "print(f\"status:          {profile['status']}\")\n",
-    "print(f\"inscription:     {profile['inscription_date']}  →  {profile['cancellation_date'] or '(active)'}\")\n",
+    "print(\n",
+    "    f\"inscription:     {profile['inscription_date']}  →  {profile['cancellation_date'] or '(active)'}\"\n",
+    ")\n",
     "print(f\"lei:             {profile.get('lei')}\")\n",
     "print()\n",
     "print(f\"risk_score:      {profile['risk_score']} / 100\")\n",
@@ -166,7 +168,9 @@
    ],
    "source": [
     "for d in profile[\"directors_current\"]:\n",
-    "    print(f\"  {d['cargo']:12s}  {d['persona_rut']:13s}  {d['nombre']:40s}  desde {d['fecha_inicio']}\")"
+    "    print(\n",
+    "        f\"  {d['cargo']:12s}  {d['persona_rut']:13s}  {d['nombre']:40s}  desde {d['fecha_inicio']}\"\n",
+    "    )"
    ]
   },
   {
@@ -333,9 +337,9 @@
     "    print(f\"[{i}] {s.get('cmf_resolucion_id', '?')}\")\n",
     "    print(f\"    fecha_resolucion: {s.get('fecha_resolucion')}\")\n",
     "    print(f\"    infraccion:       {s.get('infraccion', '')[:80]}\")\n",
-    "    if s.get('multa_uf') is not None:\n",
+    "    if s.get(\"multa_uf\") is not None:\n",
     "        print(f\"    multa:            {s['multa_uf']} UF\")\n",
-    "    if s.get('source_url'):\n",
+    "    if s.get(\"source_url\"):\n",
     "        print(f\"    source:           {s['source_url']}\")\n",
     "    print()"
    ]
@@ -452,7 +456,9 @@
     "    cargos = person.get(\"cargos_vigentes\", [])\n",
     "    print(f\"  cargos vigentes ({len(cargos)}):\")\n",
     "    for c in cargos[:5]:\n",
-    "        print(f\"    • {c['cargo']} en {c['entity_name']} ({c['entity_rut']}) desde {c['fecha_inicio']}\")\n",
+    "        print(\n",
+    "            f\"    • {c['cargo']} en {c['entity_name']} ({c['entity_rut']}) desde {c['fecha_inicio']}\"\n",
+    "        )\n",
     "    if len(cargos) > 5:\n",
     "        print(f\"    … {len(cargos) - 5} more\")\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,8 +150,13 @@ ignore = [
 # not a lingering debug statement. Suppressing the `T20` category keeps the
 # example bodies copy-paste-ready without `# noqa` comments sprinkled on every
 # line. Also allow `typing.Any` inside examples: design partners read these as
-# flat scripts, not strictly-typed library code.
+# flat scripts, not strictly-typed library code. Notebooks are documentation
+# with inline output — they need every rule the scripts get, plus a few more
+# that make sense for narrative code (unused imports from pprint/datetime,
+# hardcoded RUTs as string literals, f-strings without interpolation in
+# section headers, etc).
 "examples/**/*.py" = ["T201", "T203"]
+"examples/notebooks/**/*.ipynb" = ["T201", "T203", "F401", "F541", "E402", "E501", "E702", "B007"]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Realistic 6-endpoint demo of the SDK's aggregate surface on a single entity. Complements the existing 01-kyb-quickstart.ipynb by showing how to build a complete regulatory picture: KYB aggregate, entity detail, sanctions list, LEI ownership, per-director PEP-lite, and point-in-time `as_of` snapshot.

Outputs are included (executed against prod on 2026-04-24).