### PR TITLE
fix(urls): api.cerberus.cl → compliance.cerberus.cl (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `cerberus-compliance` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.1] — 2026-04-27
+
+### Fixed
+
+- **Documentation, examples and codegen URLs** corrected. `docs/auth.md`,
+  `examples/notebooks/01-kyb-quickstart.ipynb`, and `scripts/codegen.sh`
+  still referenced the obsolete `api.cerberus.cl` /
+  `staging-api.cerberus.cl` hosts in code samples and the OpenAPI fetch
+  URL. The runtime client (`cerberus_compliance.client`) was already
+  correct since v0.3.0 — no behavioural change for consumers using the
+  default `base_url`. Anyone who copy-pasted the sample `base_url=` in
+  `docs/auth.md` would have hit an unresolvable host; this release
+  removes those broken references.
+
 ## [v0.5.0] — 2026-04-27
 
 P5.4.2 commercial extensions — five new resources, four extended

--- a/cerberus_compliance/__init__.py
+++ b/cerberus_compliance/__init__.py
@@ -1,6 +1,6 @@
 """Official Python SDK for the Cerberus Compliance API (Chile RegTech)."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
 from cerberus_compliance.errors import (

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -70,11 +70,11 @@ from cerberus_compliance import CerberusClient
 
 client = CerberusClient(
     api_key="ck_test_...",
-    base_url="https://staging-api.cerberus.cl/v1",
+    base_url="https://staging-compliance.cerberus.cl/v1",
 )
 ```
 
-The default is `https://api.cerberus.cl/v1`. A trailing slash on `base_url` is
+The default is `https://compliance.cerberus.cl/v1`. A trailing slash on `base_url` is
 stripped automatically — both `https://example.com/v1` and `https://example.com/v1/`
 work identically. During unit tests you can point the SDK at a `respx` or
 `http.server` mock running on `http://127.0.0.1:<port>`.
@@ -91,7 +91,7 @@ from cerberus_compliance import CerberusClient
 
 transport = httpx.HTTPTransport(proxy="http://corp-proxy:3128", retries=0)
 my_http = httpx.Client(
-    base_url="https://api.cerberus.cl/v1",
+    base_url="https://compliance.cerberus.cl/v1",
     timeout=30.0,
     transport=transport,
     verify="/etc/ssl/corp-ca-bundle.pem",

--- a/examples/notebooks/01-kyb-quickstart.ipynb
+++ b/examples/notebooks/01-kyb-quickstart.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "client = CerberusClient(\n",
     "    api_key=os.environ.get(\"CERBERUS_API_KEY\", \"ck_demo_replace_me\"),\n",
-    "    base_url=os.environ.get(\"CERBERUS_BASE_URL\", \"https://api.cerberus.cl/v1\"),\n",
+    "    base_url=os.environ.get(\"CERBERUS_BASE_URL\", \"https://compliance.cerberus.cl/v1\"),\n",
     ")\n",
     "client"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.5.0"
+version = "0.5.1"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -4,7 +4,7 @@
 # the SDK is out of sync with the backend and must be regenerated + re-committed.
 set -euo pipefail
 
-SPEC_URL="${CERBERUS_OPENAPI_URL:-https://staging-api.cerberus.cl/v1/openapi.json}"
+SPEC_URL="${CERBERUS_OPENAPI_URL:-https://staging-compliance.cerberus.cl/v1/openapi.json}"
 OUT_DIR="cerberus_compliance/_generated"
 TMP_SPEC="$(mktemp -t cerberus-openapi.XXXXXX.json)"
 trap 'rm -f "$TMP_SPEC"' EXIT

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -82,8 +82,8 @@ EXPECTED_ALL = {
 }
 
 
-def test_version_is_v0_5_0() -> None:
-    assert cerberus_compliance.__version__ == "0.5.0"
+def test_version_is_v0_5_1() -> None:
+    assert cerberus_compliance.__version__ == "0.5.1"
 
 
 def test_all_matches_expected_surface() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "cerberus-compliance"
-version = "0.4.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -715,7 +715,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
 wheels = [
@@ -812,7 +812,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405 }
 wheels = [


### PR DESCRIPTION
## Summary
- Three artifacts still referenced the unresolvable `api.cerberus.cl` / `staging-api.cerberus.cl` hosts — runtime client was correct since v0.3.0 but copy-pasting from these would have failed:
  - `docs/auth.md` — three sample `base_url=` snippets
  - `examples/notebooks/01-kyb-quickstart.ipynb` — fallback `CERBERUS_BASE_URL` default
  - `scripts/codegen.sh` — staging OpenAPI fetch URL
- Bumps to **v0.5.1** (patch — no API surface change). Updates `pyproject.toml`, `__init__.__version__`, `tests/test_public_api.py::test_version_is_v0_5_1`, `uv.lock`, and a new `CHANGELOG` entry.
- Backend fix landed in `cerberus_compliance#152` (commit `5100afe`); this is the SDK-side completion.

## Test plan
- [x] `grep -r api.cerberus.cl . --exclude=CHANGELOG.md` returns zero hits
- [x] `pytest tests/test_public_api.py::test_version_is_v0_5_1` — passes
- [ ] CI: lint + typecheck + tests
- [ ] After merge: tag `v0.5.1` and publish to TestPyPI canary, then PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)