### PR TITLE
feat(lei): typed resource /v1/lei — restaura invariante drift-0 (SDK-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `cerberus-compliance` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.0] — 2026-06-12
+
+Restores the **0-drift** invariant broken by the backend's `/v1/lei` router: the
+GLEIF **Legal Entity Identifier** registry (2 endpoints, ~1 663 records) was
+shipped without its mirror SDK resource. Coverage is back to **0 uncovered / 0
+rotten** (111 covered, verified against the live prod OpenAPI).
+
+### Added — new resource
+
+- **`client.lei`** — GLEIF LEI registry over `cmf_lei_records`: `list`
+  (filters `jurisdiction`, `registration_status`, `rut`; `limit`/`offset`),
+  `get(lei)` (case-insensitive 20-char code; 404 when absent) and `iter_all`.
+  Unlike the cursor-paginated collections, `/lei` paginates by `limit`/`offset`
+  (`{items, total, limit, offset}` envelope), so `iter_all` walks by offset.
+  Ships sync + async, strict-`mypy` clean, with `respx`-mocked unit tests.
+
 ## [v0.7.0] — 2026-06-07
 
 Full API coverage. 18 new typed resources + 4 extended resources wrap the

--- a/cerberus_compliance/__init__.py
+++ b/cerberus_compliance/__init__.py
@@ -1,6 +1,6 @@
 """Official Python SDK for the Cerberus Compliance API (Chile RegTech)."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
 from cerberus_compliance.errors import (

--- a/cerberus_compliance/client.py
+++ b/cerberus_compliance/client.py
@@ -101,6 +101,7 @@ from cerberus_compliance.resources.kyb import (
     AsyncKYBResource,
     KYBResource,
 )
+from cerberus_compliance.resources.lei import AsyncLeiResource, LeiResource
 from cerberus_compliance.resources.normativa import (
     AsyncNormativaResource,
     NormativaResource,
@@ -330,6 +331,7 @@ class CerberusClient:
         # v0.4.0 — 9 new resources (P5.3)
         self.resoluciones = ResolucionesResource(self)
         self.opas = OPAsResource(self)
+        self.lei = LeiResource(self)
         self.tdc = TDCResource(self)
         self.art12 = Art12Resource(self)
         self.art20 = Art20Resource(self)
@@ -542,6 +544,7 @@ class AsyncCerberusClient:
         # v0.4.0 — 9 new resources (P5.3)
         self.resoluciones = AsyncResolucionesResource(self)
         self.opas = AsyncOPAsResource(self)
+        self.lei = AsyncLeiResource(self)
         self.tdc = AsyncTDCResource(self)
         self.art12 = AsyncArt12Resource(self)
         self.art20 = AsyncArt20Resource(self)

--- a/cerberus_compliance/resources/__init__.py
+++ b/cerberus_compliance/resources/__init__.py
@@ -72,6 +72,7 @@ from cerberus_compliance.resources.kyb import (
     AsyncKYBResource,
     KYBResource,
 )
+from cerberus_compliance.resources.lei import AsyncLeiResource, LeiResource
 from cerberus_compliance.resources.normativa import (
     AsyncNormativaResource,
     NormativaResource,
@@ -174,6 +175,7 @@ __all__ = [
     "AsyncIndicadoresResource",
     "AsyncInsiderResource",
     "AsyncKYBResource",
+    "AsyncLeiResource",
     "AsyncNormativaConsultaResource",
     "AsyncNormativaHistoricResource",
     "AsyncNormativaResource",
@@ -215,6 +217,7 @@ __all__ = [
     "InsiderResource",
     "InsiderSubjectType",
     "KYBResource",
+    "LeiResource",
     "NormativaConsultaEstado",
     "NormativaConsultaResource",
     "NormativaHistoricResource",

--- a/cerberus_compliance/resources/lei.py
+++ b/cerberus_compliance/resources/lei.py
@@ -1,0 +1,193 @@
+"""Typed accessor for the Cerberus Compliance ``/lei`` resource (SDK-01).
+
+The ``/lei`` family exposes the GLEIF **Legal Entity Identifier** registry
+mirrored into ``cmf_lei_records``: each record carries the 20-char ISO 17442
+code, the legal name/address, the GLEIF registration status, the direct and
+ultimate parent LEI, and the Chilean RUT extracted from the GLEIF record when
+present.
+
+Unlike the cursor-paginated collections, ``/lei`` paginates by ``limit`` /
+``offset`` and returns an ``{items, total, limit, offset}`` envelope, so
+:meth:`LeiResource.iter_all` walks by offset rather than cursor.
+
+Example
+-------
+.. code-block:: python
+
+    from cerberus_compliance import CerberusClient
+
+    with CerberusClient() as client:
+        page = client.lei.list(jurisdiction="CL", limit=50)
+        record = client.lei.get("5493001KJTIIGC8Y1R12")
+        for rec in client.lei.iter_all(registration_status="ISSUED"):
+            ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+__all__ = ["AsyncLeiResource", "LeiResource"]
+
+#: Server-side page cap for ``GET /v1/lei`` (``le=100``); the default iteration
+#: page size for :meth:`LeiResource.iter_all`.
+_MAX_PAGE_SIZE = 100
+
+
+def _list_params(
+    *,
+    jurisdiction: str | None,
+    registration_status: str | None,
+    rut: str | None,
+    limit: int | None,
+    offset: int | None,
+) -> dict[str, Any] | None:
+    """Assemble the ``GET /lei`` query dict, dropping ``None`` values."""
+    raw: dict[str, Any] = {
+        "jurisdiction": jurisdiction,
+        "registration_status": registration_status,
+        "rut": rut,
+        "limit": limit,
+        "offset": offset,
+    }
+    cleaned = {k: v for k, v in raw.items() if v is not None}
+    return cleaned or None
+
+
+class LeiResource(BaseResource):
+    """Synchronous accessor for the ``/lei`` GLEIF registry endpoint family."""
+
+    _path_prefix = "/lei"
+
+    def list(
+        self,
+        *,
+        jurisdiction: str | None = None,
+        registration_status: str | None = None,
+        rut: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List LEI records matching the supplied filters.
+
+        Args:
+            jurisdiction: ISO 3166-1 alpha-2 jurisdiction (e.g. ``"CL"``).
+            registration_status: GLEIF status (e.g. ``"ISSUED"``, ``"LAPSED"``).
+            rut: Chilean RUT extracted from the GLEIF record; canonicalised
+                server-side so dotted / DV-less inputs still match.
+            limit: Page size (server default 20, max 100).
+            offset: Zero-based offset.
+
+        Returns:
+            The ``items`` array of the paginated envelope.
+        """
+        return self._list(
+            params=_list_params(
+                jurisdiction=jurisdiction,
+                registration_status=registration_status,
+                rut=rut,
+                limit=limit,
+                offset=offset,
+            )
+        )
+
+    def get(self, lei: str) -> dict[str, Any]:
+        """Fetch a single LEI record by its 20-char code (case-insensitive)."""
+        return self._get(lei)
+
+    def iter_all(
+        self,
+        *,
+        jurisdiction: str | None = None,
+        registration_status: str | None = None,
+        rut: str | None = None,
+        page_size: int = _MAX_PAGE_SIZE,
+    ) -> Iterator[dict[str, Any]]:
+        """Walk every matching LEI record, paginating by ``offset``.
+
+        ``/lei`` is not cursor-paginated, so this issues successive
+        ``?limit=&offset=`` requests until a short page (or ``offset >=
+        total``) signals the end.
+        """
+        offset = 0
+        while True:
+            body = self._client._request(
+                "GET",
+                self._path_prefix,
+                params=_list_params(
+                    jurisdiction=jurisdiction,
+                    registration_status=registration_status,
+                    rut=rut,
+                    limit=page_size,
+                    offset=offset,
+                ),
+            )
+            items = self._extract_items(body)
+            yield from items
+            offset += len(items)
+            total = body.get("total")
+            if not items or len(items) < page_size or (isinstance(total, int) and offset >= total):
+                return
+
+
+class AsyncLeiResource(AsyncBaseResource):
+    """Asynchronous mirror of :class:`LeiResource`."""
+
+    _path_prefix = "/lei"
+
+    async def list(
+        self,
+        *,
+        jurisdiction: str | None = None,
+        registration_status: str | None = None,
+        rut: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async variant of :meth:`LeiResource.list`."""
+        return await self._list(
+            params=_list_params(
+                jurisdiction=jurisdiction,
+                registration_status=registration_status,
+                rut=rut,
+                limit=limit,
+                offset=offset,
+            )
+        )
+
+    async def get(self, lei: str) -> dict[str, Any]:
+        """Async variant of :meth:`LeiResource.get`."""
+        return await self._get(lei)
+
+    async def iter_all(
+        self,
+        *,
+        jurisdiction: str | None = None,
+        registration_status: str | None = None,
+        rut: str | None = None,
+        page_size: int = _MAX_PAGE_SIZE,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async variant of :meth:`LeiResource.iter_all` (paginates by offset)."""
+        offset = 0
+        while True:
+            body = await self._client._request(
+                "GET",
+                self._path_prefix,
+                params=_list_params(
+                    jurisdiction=jurisdiction,
+                    registration_status=registration_status,
+                    rut=rut,
+                    limit=page_size,
+                    offset=offset,
+                ),
+            )
+            items = self._extract_items(body)
+            for item in items:
+                yield item
+            offset += len(items)
+            total = body.get("total")
+            if not items or len(items) < page_size or (isinstance(total, int) and offset >= total):
+                return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.7.0"
+version = "0.8.0"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/check_sdk_drift.py
+++ b/scripts/check_sdk_drift.py
@@ -124,6 +124,9 @@ RESOURCE_COVERAGE: dict[tuple[str, str], tuple[str, str]] = {
     # coverage table so the drift report stays 0-rotten.
     ("GET", "/resoluciones"): ("resoluciones", "list"),
     ("GET", "/opas"): ("opas", "list"),
+    # SDK-01 — GLEIF LEI registry (cmf_lei_records); offset-paginated.
+    ("GET", "/lei"): ("lei", "list"),
+    ("GET", "/lei/{lei}"): ("lei", "get"),
     ("GET", "/tdc"): ("tdc", "list"),
     ("GET", "/art12"): ("art12", "list"),
     ("GET", "/art20"): ("art20", "list"),

--- a/tests/resources/test_lei.py
+++ b/tests/resources/test_lei.py
@@ -1,0 +1,114 @@
+"""Tests for ``cerberus_compliance.resources.lei`` (SDK-01).
+
+``/v1/lei`` is the GLEIF Legal Entity Identifier registry. Unlike the
+cursor-paginated collections, it paginates by ``limit``/``offset`` and returns
+an ``{items, total, limit, offset}`` envelope, so :meth:`LeiResource.iter_all`
+walks by offset (not cursor).
+"""
+
+from __future__ import annotations
+
+import httpx
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.lei import AsyncLeiResource, LeiResource
+
+
+class TestLeiMeta:
+    def test_sync_prefix(self) -> None:
+        assert LeiResource._path_prefix == "/lei"
+
+    def test_async_prefix(self) -> None:
+        assert AsyncLeiResource._path_prefix == "/lei"
+
+    def test_sync_subclass(self) -> None:
+        assert issubclass(LeiResource, BaseResource)
+
+    def test_async_subclass(self) -> None:
+        assert issubclass(AsyncLeiResource, AsyncBaseResource)
+
+
+class TestLeiSync:
+    def test_list(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.get("/lei").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "items": [{"lei": "5493001KJTIIGC8Y1R12"}, {"lei": "529900T8BM49AURSDO55"}],
+                    "total": 2,
+                    "limit": 20,
+                    "offset": 0,
+                },
+            )
+        )
+        result = LeiResource(sync_client).list()
+        assert [r["lei"] for r in result] == ["5493001KJTIIGC8Y1R12", "529900T8BM49AURSDO55"]
+        assert route.called
+
+    def test_list_typed_filters_drop_none(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/lei", params={"jurisdiction": "CL", "registration_status": "ISSUED"}
+        ).mock(return_value=httpx.Response(200, json={"items": [], "total": 0}))
+        LeiResource(sync_client).list(jurisdiction="CL", registration_status="ISSUED", rut=None)
+        assert route.called
+
+    def test_get(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.get("/lei/5493001KJTIIGC8Y1R12").mock(
+            return_value=httpx.Response(
+                200, json={"lei": "5493001KJTIIGC8Y1R12", "legal_name": "X"}
+            )
+        )
+        out = LeiResource(sync_client).get("5493001KJTIIGC8Y1R12")
+        assert out["legal_name"] == "X"
+        assert route.called
+
+    def test_iter_all_paginates_by_offset(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/lei", params={"limit": "2", "offset": "0"}).mock(
+            return_value=httpx.Response(
+                200, json={"items": [{"lei": "A"}, {"lei": "B"}], "total": 3}
+            )
+        )
+        respx_mock.get("/lei", params={"limit": "2", "offset": "2"}).mock(
+            return_value=httpx.Response(200, json={"items": [{"lei": "C"}], "total": 3})
+        )
+        out = list(LeiResource(sync_client).iter_all(page_size=2))
+        assert [r["lei"] for r in out] == ["A", "B", "C"]
+
+
+class TestLeiAsync:
+    async def test_list(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/lei").mock(
+            return_value=httpx.Response(200, json={"items": [{"lei": "Z"}], "total": 1})
+        )
+        assert await AsyncLeiResource(async_client).list() == [{"lei": "Z"}]
+
+    async def test_get(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/lei/ABC").mock(
+            return_value=httpx.Response(200, json={"lei": "ABC", "legal_name": "Y"})
+        )
+        out = await AsyncLeiResource(async_client).get("ABC")
+        assert out["legal_name"] == "Y"
+
+    async def test_iter_all_paginates_by_offset(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get("/lei", params={"limit": "2", "offset": "0"}).mock(
+            return_value=httpx.Response(
+                200, json={"items": [{"lei": "A"}, {"lei": "B"}], "total": 3}
+            )
+        )
+        respx_mock.get("/lei", params={"limit": "2", "offset": "2"}).mock(
+            return_value=httpx.Response(200, json={"items": [{"lei": "C"}], "total": 3})
+        )
+        collected = [r["lei"] async for r in AsyncLeiResource(async_client).iter_all(page_size=2)]
+        assert collected == ["A", "B", "C"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -132,8 +132,8 @@ EXPECTED_ALL = {
 }
 
 
-def test_version_is_v0_7_0() -> None:
-    assert cerberus_compliance.__version__.startswith("0.7.0")
+def test_version_is_v0_8_0() -> None:
+    assert cerberus_compliance.__version__.startswith("0.8.0")
 
 
 def test_all_matches_expected_surface() -> None:


### PR DESCRIPTION
## Ola 3 — canal SDK (always-on) · SDK-01 (P1)

El backend agregó el router **`/v1/lei`** (registro GLEIF de Legal Entity Identifiers — 2 endpoints, ~1.663 filas) **sin el resource espejo** en el SDK. La cobertura es hand-maintained (`RESOURCE_COVERAGE` en `scripts/check_sdk_drift.py`) y nadie la actualizó al shippear `/v1/lei` → invariante **drift-0 ROTO** (`uncovered_api=2`).

### Cambio
Nuevo **`client.lei`** (sync + async, espejo de `sanctions`):
- `list(*, jurisdiction, registration_status, rut, limit, offset)` — filtros tipados, `None` se descartan.
- `get(lei)` — detalle por código de 20 chars (case-insensitive server-side; 404 si no existe).
- `iter_all(*, jurisdiction, registration_status, rut, page_size=100)` — `/lei` **no** es cursor-paginado (envelope `{items, total, limit, offset}`), así que camina por **offset** hasta página corta / `offset >= total`.

+2 entradas en `RESOURCE_COVERAGE` (`GET /lei` → `lei.list`, `GET /lei/{lei}` → `lei.get`).

### Verificación
- **Drift contra prod restaurado**: `Covered 111, Uncovered API 0, Rotten SDK 0`.
- **1135** tests unit verdes (incl. 11 nuevos de `lei`), `ruff` + `mypy --strict` limpios.
- Versión **0.7.0 → 0.8.0** (`pyproject.toml` + `__init__.py` + test + CHANGELOG).

> El release a PyPI es tag-triggered (`release.yml`) — la publicación de `v0.8.0` la dispara un tag, no este merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)