### PR TITLE
release: 0.8.0 estable (drop rc — indicadores por series_id + buscar)

### DIFF
--- a/cerberus_compliance/__init__.py
+++ b/cerberus_compliance/__init__.py
@@ -1,6 +1,6 @@
 """Official Python SDK for the Cerberus Compliance API (Chile RegTech)."""
 
-__version__ = "0.8.0rc1"
+__version__ = "0.8.0"
 
 from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
 from cerberus_compliance.errors import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.8.0rc1"
+version = "0.8.0"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Drop del sufijo rc post-canary verde de v0.8.0rc1 en TestPyPI (build+twine+install+smoke kyb OK). Sin cambios de código — solo versión. Gate local: 1151 unit tests + cobertura 98.82% + mypy --strict + ruff limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)