### PR TITLE
fix: cierre de los hallazgos pendientes de code-review (E-plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ the backend's `/v1/lei` router.
   **`.history(series_id, from_, to)`** and
   **`.forecast(series_id, *, horizon=None)`** now take a BCCh `series_id`
   (e.g. `F073.UFF.PRE.Z.D`) instead of a friendly name. The friendly names
-  (`UF`, `UTM`, `USD`, `EUR`, `IPC`, `TMC`, `TPM`, `IMACEC`, `IMACEC_MIN`,
+  (`UF`, `UTM`, `USD`, `EUR`, `IPC`, `TPM`, `IMACEC`, `IMACEC_MIN`,
   `PIB`) and `IPC_BCH` are retired and now return **404** from the API. The
-  one non-BCCh special handle is the lowercase `tmc` (Tasa Máxima
-  Convencional, CMF/SBIF-only).
+  one exception is `TMC`: it lives on as the lowercase-canonical `tmc`
+  handle (Tasa Máxima Convencional, the sole non-BCCh series,
+  CMF/SBIF-only), and the backend matches it case-insensitively — so
+  `GET /v1/indicadores/TMC` still resolves (200, echoed back as
+  `name: "tmc"`) rather than 404ing.
 
 ### Removed
 

--- a/cerberus_compliance/resources/indicadores.py
+++ b/cerberus_compliance/resources/indicadores.py
@@ -348,6 +348,13 @@ class IndicadoresResource(BaseResource):
         All parameters are keyword-only and optional — searching by
         frequency/family alone (no ``q``) is valid.
 
+        ``limit``/``offset`` are validated **server-side** (the API
+        declares ``1 <= limit <= 100`` and ``offset >= 0``); out-of-range
+        values are rejected with a clean 422 naming the offending param
+        (e.g. ``limit=-1`` → ``"Input should be greater than or equal
+        to 1"``), surfaced as :class:`ValidationError`. No client-side
+        clamping is applied — the server error is authoritative.
+
         Returns:
             The list of matching items, unwrapped from the server
             envelope for ergonomics — each element is
@@ -355,6 +362,10 @@ class IndicadoresResource(BaseResource):
             "tracked", "has_forecast"}``. The server ranks ``tracked``
             series first. Pass a resulting ``series_id`` to
             :meth:`get` / :meth:`forecast`.
+
+        Raises:
+            ValidationError: ``limit``/``offset`` out of range, or an
+                unknown ``frequency`` value (server 422).
         """
         path = f"{self._path_prefix}/buscar"
         params = _clean_params(

--- a/examples/indicadores_basic.py
+++ b/examples/indicadores_basic.py
@@ -123,15 +123,18 @@ def _run(client: CerberusClient) -> None:
     _print_header("5. indicadores.buscar(q='cobre') — discovery over ~25k BCCh series")
     matches = client.indicadores.buscar(q="cobre", limit=5)
     print(f"  matches returned: {len(matches)}")
+    if not matches:
+        print("  (no series matched 'cobre')")
+        return
     for row in matches[:3]:
         title = _fmt(row.get("title_es"))
         if len(title) > 56:
             title = f"{title[:53]}..."
         print(f"  - {_fmt(row.get('series_id')):38s} {title}")
-    if not matches:
-        print("  (no series matched 'cobre')")
+    discovered_id = matches[0].get("series_id")
+    if not isinstance(discovered_id, str) or not discovered_id:
+        print("  (first match carries no series_id — skipping get/forecast demo)")
         return
-    discovered_id = str(matches[0]["series_id"])
 
     _print_header(f"6. indicadores.get('{discovered_id}') — latest discovered value")
     try:

--- a/tests/integration/test_live_prod.py
+++ b/tests/integration/test_live_prod.py
@@ -252,14 +252,18 @@ class TestProdIndicadores:
         assert isinstance(rows, list)
 
     def test_retired_name_404s(self, live_client: CerberusClient) -> None:
-        """Friendly names are retired: ``get("UF")`` must raise (404).
+        """Friendly names are retired: ``get("UF")`` must raise ``NotFoundError``.
 
         Since Plan A (series_id-canonical) is deployed, the friendly name
         ``"UF"`` no longer resolves — the canonical handle is the BCCh
-        ``series_id``. This is permanent, expected behaviour, so the 404
-        is a strict PASS (never xfail): it proves the retirement is live.
+        ``series_id``. This is permanent, designed behaviour, so the 404
+        is a strict PASS (never xfail) and the expected exception is
+        exactly :class:`NotFoundError` — a broader
+        ``(NotFoundError, CerberusAPIError)`` tuple would be degenerate
+        (``NotFoundError`` subclasses ``CerberusAPIError``, so any API
+        error would pass) and stop proving the retirement is live.
         """
-        with pytest.raises((NotFoundError, CerberusAPIError)):
+        with pytest.raises(NotFoundError):
             live_client.indicadores.get("UF")
 
     def test_list_catalog_returns_tracked_series(self, live_client: CerberusClient) -> None:

--- a/tests/resources/test_indicadores.py
+++ b/tests/resources/test_indicadores.py
@@ -91,22 +91,25 @@ class TestIndicadoresGet:
 
         ``urllib.parse.quote`` never percent-encodes ``.`` (unreserved),
         so ``F073.UFF.PRE.Z.D`` must reach the server literally — this is
-        the canonical-handle contract (series_id in, ``title_es`` out).
+        the canonical-handle contract (series_id in; the live wire echoes
+        it back under the ``name`` key, alongside ``title_es``).
         """
         route = respx_mock.get("/indicadores/F073.UFF.PRE.Z.D").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "series_id": "F073.UFF.PRE.Z.D",
+                    "name": "F073.UFF.PRE.Z.D",
                     "title_es": "Unidad de fomento (UF)",
                     "value": "39421.73",
+                    "date": "2026-04-24",
+                    "source": "bcentral_api",
                 },
             )
         )
         resource = IndicadoresResource(sync_client)
         result = resource.get("F073.UFF.PRE.Z.D")
         assert route.called
-        assert result["series_id"] == "F073.UFF.PRE.Z.D"
+        assert result["name"] == "F073.UFF.PRE.Z.D"
         assert result["title_es"]
         # The dots must NOT be percent-encoded on the wire.
         assert route.calls.last.request.url.path.endswith("/indicadores/F073.UFF.PRE.Z.D")
@@ -579,6 +582,40 @@ class TestIndicadoresBuscar:
         results = resource.buscar(q="uf")
         assert len(results) == 1
         assert results[0]["series_id"] == "F073.UFF.PRE.Z.D"
+
+    def test_buscar_422_limit_out_of_range(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        """``limit``/``offset`` validation is server-side by design.
+
+        The API declares ``1 <= limit <= 100`` / ``offset >= 0`` (FastAPI
+        ``ge``/``le``); out-of-range values come back as a clean 422 with
+        the offending param named, which the SDK surfaces verbatim as
+        :class:`ValidationError` — no client-side clamping.
+        """
+        respx_mock.get("/indicadores/buscar", params={"q": "cobre", "limit": "-1"}).mock(
+            return_value=httpx.Response(
+                422,
+                json={
+                    "type": "about:blank",
+                    "title": "Validation error",
+                    "status": 422,
+                    "detail": "Request validation failed. See 'errors' for details.",
+                    "errors": [
+                        {
+                            "type": "greater_than_equal",
+                            "loc": ["query", "limit"],
+                            "msg": "Input should be greater than or equal to 1",
+                            "input": "-1",
+                            "ctx": {"ge": 1},
+                        }
+                    ],
+                },
+            )
+        )
+        resource = IndicadoresResource(sync_client)
+        with pytest.raises(ValidationError):
+            resource.buscar(q="cobre", limit=-1)
 
     def test_buscar_empty_returns_empty_list(
         self, sync_client: CerberusClient, respx_mock: respx.MockRouter


### PR DESCRIPTION
## Resumen

Cierra los 6 hallazgos restantes de las revisiones de calidad del E-plan. Cambios quirúrgicos, solo tests/docs/ejemplo — sin bump de versión ni release.

## Hallazgos cerrados

1. **`test_get_dotted_series_id_path_not_mangled` — mock con shape irreal** (`tests/resources/test_indicadores.py`): el body respx usaba la clave `series_id`, pero el wire real de prod devuelve `name` (+ `title_es`, `value`, `date`, `source`). Mock corregido al shape real y asserts sobre `result["name"]`; la clase ahora documenta UN solo contrato (consistente con `test_get_latest_no_date_param`).
2. **`test_retired_name_404s` — `pytest.raises` degenerado** (`tests/integration/test_live_prod.py`): `(NotFoundError, CerberusAPIError)` dejaba pasar cualquier error de API (subclase). Endurecido a `pytest.raises(NotFoundError)` estricto (el 404 es comportamiento diseñado permanente). **Verificado en vivo contra prod: 1 passed.**
3. **CHANGELOG v0.8.0 — claim falso sobre `TMC`**: decía que `TMC` «now returns 404». Verificado en vivo: `GET /v1/indicadores/TMC` → **200** (`name: "tmc"`) — el backend resuelve el handle especial `tmc` case-insensitively. Redacción corregida: `TMC` sobrevive como handle canónico en minúscula; los demás nombres amigables sí 404ean.
4. **`examples/indicadores_basic.py` — subscript desnudo + guard mal ubicado**: el guard de `matches` vacío ahora va ANTES de cualquier acceso a la lista, y `matches[0]["series_id"]` pasó a `.get("series_id")` defensivo con skip+mensaje. **Ejecutado end-to-end contra prod: secciones 1–7 OK** (UF, USD/CLP, history 120 filas, buscar cobre 5 matches, get + forecast TimesFM del series descubierto).
5. **`buscar` — validación de `limit`/`offset` (minor E.1.2 #2 truncado)**: juzgado contra prod — el servidor 422ea limpio y accionable (`limit=-1`/`0`/`101`, `offset=-5`, `frequency=BOGUS` → 422 con el param infractor nombrado, surfaced como `ValidationError`). Decisión: **sin clamps client-side**; documentado en el docstring (validación server-side, `1 <= limit <= 100`, `offset >= 0`) + nuevo test unitario `test_buscar_422_limit_out_of_range` que fija el contrato.
6. **Sweep `IPC_BCH`**: sin ocurrencias fuera de entradas del CHANGELOG (documentación del retiro mismo) — nada que remover en `cerberus_compliance/`, `tests/`, `examples/` ni `README.md`.

## Verificación

- `pytest tests/ -q --ignore=tests/integration` → **1152 passed**, coverage **98.82%** (gate ≥95%).
- `ruff check` (archivos tracked) + `ruff format --check` → limpio.
- `mypy --strict cerberus_compliance/` → **0 errores** (51 archivos).
- Integración en vivo: `test_retired_name_404s` passed contra prod; ejemplo ejecutado contra prod sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)