### PR TITLE
feat(sdk): v0.9.0 — cobertura de superficies nuevas (drift 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `cerberus-compliance` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.0] — 2026-07-04
+
+Cobertura de las superficies nuevas de la API: la deriva del SDK vuelve a **0
+uncovered / 0 rotten** contra producción (120 endpoints cubiertos).
+
+### Added
+
+- **`client.diario.list_normas`** / **`iter_all_normas`** — normas generales del
+  Cuerpo I del Diario Oficial (`GET /diario/normas`): leyes, decretos, DFL,
+  resoluciones exentas y reglamentos con sus facetas legales, filtrables por
+  `tipo` (`DiarioNormaTipo`), `desde`/`hasta`, `faceta` y `q`. Paginación offset.
+- **`client.equity.forecast`** — pronóstico TimesFM de precios por ticker
+  (`GET /equity/{ticker}/forecast`).
+- **`client.legal.search`** / **`iter_all`** — búsqueda sobre el corpus legal
+  consolidado de la BCN (`GET /legal/search`), paginada por cursor, con filtros
+  `q`, `facetas` y `estado`.
+- **`client.regulatory_impact.get`** — detalle de una evaluación de impacto
+  regulatorio por id (`GET /regulatory-impact/{impact_id}`).
+- **`client.regulatory_subscriptions.get` / `.update`** — perfil de suscripción
+  regulatoria de la organización (`GET`/`PUT /regulatory-subscriptions`).
+
+Todas las superficies con su gemelo asíncrono en `AsyncCerberusClient`.
+
 ## [v0.8.0] — 2026-06-30
 
 The canonical handle for `client.indicadores` is now the BCCh **`series_id`**

--- a/cerberus_compliance/__init__.py
+++ b/cerberus_compliance/__init__.py
@@ -1,6 +1,6 @@
 """Official Python SDK for the Cerberus Compliance API (Chile RegTech)."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
 from cerberus_compliance.errors import (
@@ -36,6 +36,7 @@ from cerberus_compliance.resources.copilot import (
 from cerberus_compliance.resources.diario import (
     AsyncDiarioResource,
     DiarioEventoTipo,
+    DiarioNormaTipo,
     DiarioResource,
 )
 from cerberus_compliance.resources.dictamenes import (
@@ -92,6 +93,10 @@ from cerberus_compliance.resources.kyb import (
     AsyncKYBResource,
     KYBResource,
 )
+from cerberus_compliance.resources.legal import (
+    AsyncLegalResource,
+    LegalResource,
+)
 from cerberus_compliance.resources.normativa import (
     AsyncNormativaResource,
     NormativaResource,
@@ -128,6 +133,14 @@ from cerberus_compliance.resources.regulations import (
     AsyncRegulationsResource,
     RegulationsResource,
     RegulationType,
+)
+from cerberus_compliance.resources.regulatory_impact import (
+    AsyncRegulatoryImpactResource,
+    RegulatoryImpactResource,
+)
+from cerberus_compliance.resources.regulatory_subscriptions import (
+    AsyncRegulatorySubscriptionsResource,
+    RegulatorySubscriptionsResource,
 )
 from cerberus_compliance.resources.rentas import (
     AsyncRentasResource,
@@ -212,6 +225,7 @@ __all__ = [
     "AsyncIndicadoresResource",
     "AsyncInsiderResource",
     "AsyncKYBResource",
+    "AsyncLegalResource",
     "AsyncNormativaConsultaResource",
     "AsyncNormativaHistoricResource",
     "AsyncNormativaResource",
@@ -222,6 +236,8 @@ __all__ = [
     "AsyncRPSFResource",
     "AsyncRatingsResource",
     "AsyncRegulationsResource",
+    "AsyncRegulatoryImpactResource",
+    "AsyncRegulatorySubscriptionsResource",
     "AsyncRentasResource",
     "AsyncResolucionesResource",
     "AsyncResolveResource",
@@ -242,6 +258,7 @@ __all__ = [
     "CopilotResource",
     "CopilotStreamEvent",
     "DiarioEventoTipo",
+    "DiarioNormaTipo",
     "DiarioResource",
     "DictamenesResource",
     "ESGRankingDirection",
@@ -261,6 +278,7 @@ __all__ = [
     "InsiderResource",
     "InsiderSubjectType",
     "KYBResource",
+    "LegalResource",
     "NormativaConsultaEstado",
     "NormativaConsultaResource",
     "NormativaHistoricResource",
@@ -278,6 +296,8 @@ __all__ = [
     "RatingsResource",
     "RegulationType",
     "RegulationsResource",
+    "RegulatoryImpactResource",
+    "RegulatorySubscriptionsResource",
     "RentasResource",
     "ResolucionesResource",
     "ResolveResource",

--- a/cerberus_compliance/client.py
+++ b/cerberus_compliance/client.py
@@ -101,6 +101,10 @@ from cerberus_compliance.resources.kyb import (
     AsyncKYBResource,
     KYBResource,
 )
+from cerberus_compliance.resources.legal import (
+    AsyncLegalResource,
+    LegalResource,
+)
 from cerberus_compliance.resources.lei import AsyncLeiResource, LeiResource
 from cerberus_compliance.resources.normativa import (
     AsyncNormativaResource,
@@ -134,6 +138,14 @@ from cerberus_compliance.resources.ratings import (
 from cerberus_compliance.resources.regulations import (
     AsyncRegulationsResource,
     RegulationsResource,
+)
+from cerberus_compliance.resources.regulatory_impact import (
+    AsyncRegulatoryImpactResource,
+    RegulatoryImpactResource,
+)
+from cerberus_compliance.resources.regulatory_subscriptions import (
+    AsyncRegulatorySubscriptionsResource,
+    RegulatorySubscriptionsResource,
 )
 from cerberus_compliance.resources.rentas import (
     AsyncRentasResource,
@@ -350,6 +362,9 @@ class CerberusClient:
         self.banking = BankingResource(self)
         self.copilot = CopilotResource(self)
         self.diario = DiarioResource(self)
+        self.legal = LegalResource(self)
+        self.regulatory_impact = RegulatoryImpactResource(self)
+        self.regulatory_subscriptions = RegulatorySubscriptionsResource(self)
         self.financials = FinancialsResource(self)
         self.fondos = FondosResource(self)
         self.graph = GraphResource(self)
@@ -563,6 +578,9 @@ class AsyncCerberusClient:
         self.banking = AsyncBankingResource(self)
         self.copilot = AsyncCopilotResource(self)
         self.diario = AsyncDiarioResource(self)
+        self.legal = AsyncLegalResource(self)
+        self.regulatory_impact = AsyncRegulatoryImpactResource(self)
+        self.regulatory_subscriptions = AsyncRegulatorySubscriptionsResource(self)
         self.financials = AsyncFinancialsResource(self)
         self.fondos = AsyncFondosResource(self)
         self.graph = AsyncGraphResource(self)

--- a/cerberus_compliance/resources/diario.py
+++ b/cerberus_compliance/resources/diario.py
@@ -40,7 +40,54 @@ from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
 if TYPE_CHECKING:
     from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
 
-__all__ = ["AsyncDiarioResource", "DiarioEventoTipo", "DiarioResource"]
+__all__ = [
+    "AsyncDiarioResource",
+    "DiarioEventoTipo",
+    "DiarioNormaTipo",
+    "DiarioResource",
+]
+
+#: Tipo de instrumento de una norma del Cuerpo I del Diario Oficial
+#: (``DoNormaTipo``). Un valor fuera del enum produce un **422**.
+DiarioNormaTipo = Literal[
+    "ley",
+    "decreto_supremo",
+    "dfl",
+    "decreto_ley",
+    "resolucion_exenta",
+    "reglamento",
+    "otro",
+]
+
+
+def _build_normas_params(
+    *,
+    tipo: DiarioNormaTipo | None,
+    desde: str | None,
+    hasta: str | None,
+    faceta: str | None,
+    q: str | None,
+    limit: int | None,
+    offset: int | None,
+) -> dict[str, Any] | None:
+    """Assemble the ``/diario/normas`` query dict, dropping ``None`` values."""
+    params: dict[str, Any] = {}
+    if tipo is not None:
+        params["tipo"] = tipo
+    if desde is not None:
+        params["desde"] = desde
+    if hasta is not None:
+        params["hasta"] = hasta
+    if faceta is not None:
+        params["faceta"] = faceta
+    if q is not None:
+        params["q"] = q
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
+    return params or None
+
 
 #: The ``DoEventoTipo`` StrEnum that classifies each *Diario Oficial*
 #: corporate-lifecycle event. Unlike the advisory taxonomies elsewhere in
@@ -197,6 +244,70 @@ class DiarioResource(BaseResource):
             if len(items) < page_size:
                 return
 
+    def list_normas(
+        self,
+        *,
+        tipo: DiarioNormaTipo | None = None,
+        desde: str | None = None,
+        hasta: str | None = None,
+        faceta: str | None = None,
+        q: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """List general norms from the DO's Cuerpo I (``GET /diario/normas``).
+
+        Leyes, decretos, DFL, resoluciones exentas y reglamentos publicados en
+        la Sección Normas Generales, con sus facetas legales clasificadas.
+
+        Args:
+            tipo: One of :data:`DiarioNormaTipo`; out-of-enum yields **422**.
+            desde/hasta: ISO-8601 ``YYYY-MM-DD`` sobre ``fecha_publicacion``.
+            faceta: rama del derecho clasificada (solapamiento de facetas).
+            q: substring case-insensitive sobre el título.
+            limit: page size (1-100, default 20); offset: base-cero.
+
+        Returns:
+            ``{"items": [...], "total": int, "limit": int, "offset": int}``.
+        """
+        params = _build_normas_params(
+            tipo=tipo, desde=desde, hasta=hasta, faceta=faceta, q=q, limit=limit, offset=offset
+        )
+        return self._client._request("GET", f"{self._path_prefix}/normas", params=params)
+
+    def iter_all_normas(
+        self,
+        *,
+        tipo: DiarioNormaTipo | None = None,
+        desde: str | None = None,
+        hasta: str | None = None,
+        faceta: str | None = None,
+        q: str | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield every norm across all pages of ``GET /diario/normas``."""
+        page_size = 100
+        offset = 0
+        while True:
+            body = self.list_normas(
+                tipo=tipo,
+                desde=desde,
+                hasta=hasta,
+                faceta=faceta,
+                q=q,
+                limit=page_size,
+                offset=offset,
+            )
+            items = self._extract_items(body)
+            if not items:
+                return
+            yield from items
+            offset += len(items)
+            total = body.get("total")
+            if isinstance(total, int) and offset >= total:
+                return
+            if len(items) < page_size:
+                return
+
 
 class AsyncDiarioResource(AsyncBaseResource):
     """Asynchronous mirror of :class:`DiarioResource`.
@@ -256,6 +367,57 @@ class AsyncDiarioResource(AsyncBaseResource):
                 hasta=hasta,
                 q=q,
                 entity_id=entity_id,
+                limit=page_size,
+                offset=offset,
+            )
+            items = self._extract_items(body)
+            if not items:
+                return
+            for item in items:
+                yield item
+            offset += len(items)
+            total = body.get("total")
+            if isinstance(total, int) and offset >= total:
+                return
+            if len(items) < page_size:
+                return
+
+    async def list_normas(
+        self,
+        *,
+        tipo: DiarioNormaTipo | None = None,
+        desde: str | None = None,
+        hasta: str | None = None,
+        faceta: str | None = None,
+        q: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """Async variant of :meth:`DiarioResource.list_normas`."""
+        params = _build_normas_params(
+            tipo=tipo, desde=desde, hasta=hasta, faceta=faceta, q=q, limit=limit, offset=offset
+        )
+        return await self._client._request("GET", f"{self._path_prefix}/normas", params=params)
+
+    async def iter_all_normas(
+        self,
+        *,
+        tipo: DiarioNormaTipo | None = None,
+        desde: str | None = None,
+        hasta: str | None = None,
+        faceta: str | None = None,
+        q: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async variant of :meth:`DiarioResource.iter_all_normas`."""
+        page_size = 100
+        offset = 0
+        while True:
+            body = await self.list_normas(
+                tipo=tipo,
+                desde=desde,
+                hasta=hasta,
+                faceta=faceta,
+                q=q,
                 limit=page_size,
                 offset=offset,
             )

--- a/cerberus_compliance/resources/equity.py
+++ b/cerberus_compliance/resources/equity.py
@@ -97,6 +97,17 @@ class EquityResource(BaseResource):
         path = f"{self._path_prefix}/{_encode_id(ticker)}/prices"
         return self._client._request("GET", path, params=_build_price_params(from_=from_, to=to))
 
+    def forecast(self, ticker: str) -> dict[str, Any]:
+        """Return the TimesFM price forecast for ``ticker`` (``GET /equity/{ticker}/forecast``).
+
+        Reads the precomputed forecast row (the model is off the request
+        path).  Args: *ticker* is percent-encoded so symbols with ``.``/``/``
+        round-trip.  Returns the forecast envelope (model, horizon, points
+        with calibrated intervals, ``computed_at``, disclaimer).
+        """
+        path = f"{self._path_prefix}/{_encode_id(ticker)}/forecast"
+        return self._client._request("GET", path)
+
 
 class AsyncEquityResource(AsyncBaseResource):
     """Async mirror of :class:`EquityResource`."""
@@ -118,3 +129,8 @@ class AsyncEquityResource(AsyncBaseResource):
         return await self._client._request(
             "GET", path, params=_build_price_params(from_=from_, to=to)
         )
+
+    async def forecast(self, ticker: str) -> dict[str, Any]:
+        """Async variant of :meth:`EquityResource.forecast`."""
+        path = f"{self._path_prefix}/{_encode_id(ticker)}/forecast"
+        return await self._client._request("GET", path)

--- a/cerberus_compliance/resources/legal.py
+++ b/cerberus_compliance/resources/legal.py
@@ -1,0 +1,134 @@
+"""Typed accessor for the Cerberus Compliance ``/legal/search`` resource.
+
+Búsqueda semántica sobre el corpus legal consolidado de la BCN (leyes, decretos,
+DFL, códigos) con filtros por faceta legal, estado y texto libre. Devuelve el
+sobre paginado por cursor ``{"items": [...], "next_cursor": ..., "prev_cursor":
+..., "limit": N}``. :meth:`LegalResource.iter_all` recorre la colección
+siguiendo ``next_cursor``.
+
+Example
+-------
+.. code-block:: python
+
+    from cerberus_compliance import CerberusClient
+
+    with CerberusClient() as client:
+        page = client.legal.search(q="protección de datos", limit=10)
+        for norma in client.legal.iter_all(facetas="proteccion_datos"):
+            print(norma["numero"], norma["titulo"])
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import TYPE_CHECKING, Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+if TYPE_CHECKING:
+    from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+
+__all__ = ["AsyncLegalResource", "LegalResource"]
+
+
+def _build_params(
+    *,
+    q: str | None,
+    facetas: str | None,
+    estado: str | None,
+    cursor: str | None,
+    limit: int | None,
+) -> dict[str, Any] | None:
+    """Assemble the ``/legal/search`` query dict, dropping ``None`` values."""
+    params: dict[str, Any] = {}
+    if q is not None:
+        params["q"] = q
+    if facetas is not None:
+        params["facetas"] = facetas
+    if estado is not None:
+        params["estado"] = estado
+    if cursor is not None:
+        params["cursor"] = cursor
+    if limit is not None:
+        params["limit"] = limit
+    return params or None
+
+
+class LegalResource(BaseResource):
+    """Sync accessor for ``GET /legal/search`` (scope ``legal:read``)."""
+
+    _path_prefix = "/legal/search"
+
+    def __init__(self, client: CerberusClient) -> None:
+        super().__init__(client)
+
+    def search(
+        self,
+        *,
+        q: str | None = None,
+        facetas: str | None = None,
+        estado: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Search the consolidated legal corpus (``GET /legal/search``).
+
+        Args:
+            q: free-text query over title/full text.
+            facetas: rama del derecho clasificada (faceta legal).
+            estado: filtra por estado de la norma (p.ej. ``vigente``).
+            cursor: opaque cursor from a prior page's ``next_cursor``.
+            limit: page size.
+
+        Returns:
+            ``{"items": [...], "next_cursor": str|None,
+            "prev_cursor": str|None, "limit": int}``.
+        """
+        params = _build_params(q=q, facetas=facetas, estado=estado, cursor=cursor, limit=limit)
+        return self._client._request("GET", self._path_prefix, params=params)
+
+    def iter_all(
+        self,
+        *,
+        q: str | None = None,
+        facetas: str | None = None,
+        estado: str | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield every legal norm across all cursor pages of ``GET /legal/search``."""
+        return self._iter_all(
+            params=_build_params(q=q, facetas=facetas, estado=estado, cursor=None, limit=None)
+        )
+
+
+class AsyncLegalResource(AsyncBaseResource):
+    """Async mirror of :class:`LegalResource`."""
+
+    _path_prefix = "/legal/search"
+
+    def __init__(self, client: AsyncCerberusClient) -> None:
+        super().__init__(client)
+
+    async def search(
+        self,
+        *,
+        q: str | None = None,
+        facetas: str | None = None,
+        estado: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Async variant of :meth:`LegalResource.search`."""
+        params = _build_params(q=q, facetas=facetas, estado=estado, cursor=cursor, limit=limit)
+        return await self._client._request("GET", self._path_prefix, params=params)
+
+    def iter_all(
+        self,
+        *,
+        q: str | None = None,
+        facetas: str | None = None,
+        estado: str | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async variant of :meth:`LegalResource.iter_all`."""
+        return self._iter_all(
+            params=_build_params(q=q, facetas=facetas, estado=estado, cursor=None, limit=None)
+        )

--- a/cerberus_compliance/resources/regulatory_impact.py
+++ b/cerberus_compliance/resources/regulatory_impact.py
@@ -1,0 +1,62 @@
+"""Typed accessor for ``GET /regulatory-impact/{impact_id}``.
+
+Un *regulatory impact* es la evaluación del efecto de una norma nueva sobre el
+perfil regulatorio suscrito de la organización (sectores, facetas, RUTs). Este
+recurso expone el detalle de una evaluación puntual por su id.
+
+Example
+-------
+.. code-block:: python
+
+    from cerberus_compliance import CerberusClient
+
+    with CerberusClient() as client:
+        impacto = client.regulatory_impact.get("a1b2c3d4-...")
+        print(impacto["titulo"], impacto["severidad"])
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource, _encode_id
+
+if TYPE_CHECKING:
+    from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+
+__all__ = ["AsyncRegulatoryImpactResource", "RegulatoryImpactResource"]
+
+
+class RegulatoryImpactResource(BaseResource):
+    """Sync accessor for ``GET /regulatory-impact/{impact_id}``."""
+
+    _path_prefix = "/regulatory-impact"
+
+    def __init__(self, client: CerberusClient) -> None:
+        super().__init__(client)
+
+    def get(self, impact_id: str) -> dict[str, Any]:
+        """Return one regulatory-impact evaluation by id.
+
+        Args:
+            impact_id: UUID de la evaluación (percent-encoded).
+
+        Returns:
+            El detalle de la evaluación de impacto regulatorio.
+        """
+        path = f"{self._path_prefix}/{_encode_id(impact_id)}"
+        return self._client._request("GET", path)
+
+
+class AsyncRegulatoryImpactResource(AsyncBaseResource):
+    """Async mirror of :class:`RegulatoryImpactResource`."""
+
+    _path_prefix = "/regulatory-impact"
+
+    def __init__(self, client: AsyncCerberusClient) -> None:
+        super().__init__(client)
+
+    async def get(self, impact_id: str) -> dict[str, Any]:
+        """Async variant of :meth:`RegulatoryImpactResource.get`."""
+        path = f"{self._path_prefix}/{_encode_id(impact_id)}"
+        return await self._client._request("GET", path)

--- a/cerberus_compliance/resources/regulatory_subscriptions.py
+++ b/cerberus_compliance/resources/regulatory_subscriptions.py
@@ -1,0 +1,133 @@
+"""Typed accessor for ``/regulatory-subscriptions`` (GET + PUT).
+
+El *perfil de suscripción regulatoria* de la organización declara qué sectores
+CIIU, materias, facetas legales, fuentes y RUTs le interesan; el motor de
+impacto regulatorio lo usa para filtrar qué normas nuevas notificar.
+
+* ``GET /regulatory-subscriptions`` → el perfil actual.
+* ``PUT /regulatory-subscriptions`` → reemplaza el perfil (upsert completo).
+
+Example
+-------
+.. code-block:: python
+
+    from cerberus_compliance import CerberusClient
+
+    with CerberusClient() as client:
+        actual = client.regulatory_subscriptions.get()
+        client.regulatory_subscriptions.update(
+            sectores_ciiu=["64", "65"], facetas=["proteccion_datos"]
+        )
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+
+if TYPE_CHECKING:
+    from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+
+__all__ = [
+    "AsyncRegulatorySubscriptionsResource",
+    "RegulatorySubscriptionsResource",
+]
+
+
+def _build_body(
+    *,
+    sectores_ciiu: Sequence[str] | None,
+    materias: Sequence[str] | None,
+    facetas: Sequence[str] | None,
+    fuentes: Sequence[str] | None,
+    ruts: Sequence[str] | None,
+) -> dict[str, Any]:
+    """Assemble the PUT body, dropping ``None`` fields (partial upsert)."""
+    body: dict[str, Any] = {}
+    if sectores_ciiu is not None:
+        body["sectores_ciiu"] = list(sectores_ciiu)
+    if materias is not None:
+        body["materias"] = list(materias)
+    if facetas is not None:
+        body["facetas"] = list(facetas)
+    if fuentes is not None:
+        body["fuentes"] = list(fuentes)
+    if ruts is not None:
+        body["ruts"] = list(ruts)
+    return body
+
+
+class RegulatorySubscriptionsResource(BaseResource):
+    """Sync accessor for ``/regulatory-subscriptions`` (GET + PUT)."""
+
+    _path_prefix = "/regulatory-subscriptions"
+
+    def __init__(self, client: CerberusClient) -> None:
+        super().__init__(client)
+
+    def get(self) -> dict[str, Any]:
+        """Return the organization's current regulatory-subscription profile.
+
+        Returns:
+            ``{"sectores_ciiu": [...], "secciones_rollup": [...],
+            "materias": [...], "facetas": [...], "fuentes": [...],
+            "ruts": [...]}``.
+        """
+        return self._client._request("GET", self._path_prefix)
+
+    def update(
+        self,
+        *,
+        sectores_ciiu: Sequence[str] | None = None,
+        materias: Sequence[str] | None = None,
+        facetas: Sequence[str] | None = None,
+        fuentes: Sequence[str] | None = None,
+        ruts: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Replace the subscription profile (``PUT /regulatory-subscriptions``).
+
+        Cada lista provista reemplaza la correspondiente; las omitidas quedan
+        sin tocar (upsert parcial). Returns the updated profile.
+        """
+        body = _build_body(
+            sectores_ciiu=sectores_ciiu,
+            materias=materias,
+            facetas=facetas,
+            fuentes=fuentes,
+            ruts=ruts,
+        )
+        return self._client._request("PUT", self._path_prefix, json=body)
+
+
+class AsyncRegulatorySubscriptionsResource(AsyncBaseResource):
+    """Async mirror of :class:`RegulatorySubscriptionsResource`."""
+
+    _path_prefix = "/regulatory-subscriptions"
+
+    def __init__(self, client: AsyncCerberusClient) -> None:
+        super().__init__(client)
+
+    async def get(self) -> dict[str, Any]:
+        """Async variant of :meth:`RegulatorySubscriptionsResource.get`."""
+        return await self._client._request("GET", self._path_prefix)
+
+    async def update(
+        self,
+        *,
+        sectores_ciiu: Sequence[str] | None = None,
+        materias: Sequence[str] | None = None,
+        facetas: Sequence[str] | None = None,
+        fuentes: Sequence[str] | None = None,
+        ruts: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Async variant of :meth:`RegulatorySubscriptionsResource.update`."""
+        body = _build_body(
+            sectores_ciiu=sectores_ciiu,
+            materias=materias,
+            facetas=facetas,
+            fuentes=fuentes,
+            ruts=ruts,
+        )
+        return await self._client._request("PUT", self._path_prefix, json=body)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cerberus-compliance"
-version = "0.8.0"
+version = "0.9.0"
 description = "Official Python SDK for the Cerberus Compliance API (Chile RegTech)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/check_sdk_drift.py
+++ b/scripts/check_sdk_drift.py
@@ -192,6 +192,14 @@ RESOURCE_COVERAGE: dict[tuple[str, str], tuple[str, str]] = {
     ("GET", "/hechos/event-types"): ("hechos", "hechos_event_type_distribution"),
     ("GET", "/hechos/bancos"): ("hechos", "list_hechos_bancos"),
     ("GET", "/hechos/otros"): ("hechos", "list_hechos_otros"),
+    # v0.9.0 — nuevas superficies (diario normas, equity forecast, corpus legal,
+    # impacto y suscripciones regulatorias).
+    ("GET", "/diario/normas"): ("diario", "list_normas"),
+    ("GET", "/equity/{ticker}/forecast"): ("equity", "forecast"),
+    ("GET", "/legal/search"): ("legal", "search"),
+    ("GET", "/regulatory-impact/{impact_id}"): ("regulatory_impact", "get"),
+    ("GET", "/regulatory-subscriptions"): ("regulatory_subscriptions", "get"),
+    ("PUT", "/regulatory-subscriptions"): ("regulatory_subscriptions", "update"),
     ("GET", "/indicadores/{series_id}/forecast"): ("indicadores", "forecast"),
     ("GET", "/insider/{rut_or_persona}/profile"): ("insider", "get_profile"),
     ("GET", "/ipsa/risk-panel"): ("ipsa", "risk_panel"),
@@ -277,10 +285,9 @@ DEFERRED_COVERAGE: frozenset[tuple[str, str]] = frozenset(
         ("GET", "/copilot/conversations/{conversation_id}"),
         ("PATCH", "/copilot/conversations/{conversation_id}"),
         ("DELETE", "/copilot/conversations/{conversation_id}"),
-        ("GET", "/legal/search"),
-        ("GET", "/regulatory-impact/{impact_id}"),
-        ("GET", "/regulatory-subscriptions"),
-        ("PUT", "/regulatory-subscriptions"),
+        # legal/search, regulatory-impact y regulatory-subscriptions ya están
+        # cubiertos en 0.9.0 (client.legal / client.regulatory_impact /
+        # client.regulatory_subscriptions) — salieron de DEFERRED_COVERAGE.
     }
 )
 

--- a/tests/resources/test_diario.py
+++ b/tests/resources/test_diario.py
@@ -315,3 +315,55 @@ class TestDiarioAsync:
         resource = AsyncDiarioResource(async_client)
         with pytest.raises(CerberusAPIError):
             await resource.list_eventos()
+
+
+class TestDiarioNormasSync:
+    """v0.9.0 — GET /diario/normas."""
+
+    def test_list_normas(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        body = {"items": [{"numero": "21719", "tipo": "ley"}], "total": 1, "limit": 20, "offset": 0}
+        route = respx_mock.get("/diario/normas").mock(return_value=httpx.Response(200, json=body))
+        result = DiarioResource(sync_client).list_normas()
+        assert result == body
+        assert route.called
+
+    def test_list_normas_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/diario/normas",
+            params={
+                "tipo": "ley",
+                "faceta": "proteccion_datos",
+                "desde": "2024-01-01",
+                "limit": "5",
+            },
+        ).mock(return_value=httpx.Response(200, json={"items": [], "total": 0}))
+        DiarioResource(sync_client).list_normas(
+            tipo="ley", faceta="proteccion_datos", desde="2024-01-01", limit=5
+        )
+        assert route.called
+
+    def test_iter_all_normas(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        # Paginación offset (page_size=100): las 2 normas caben en una página y el
+        # iterador se detiene (empty page en offset=2 no es necesario porque
+        # len(items) < page_size ya cierra).
+        page = {"items": [{"numero": "1"}, {"numero": "2"}], "total": 2, "limit": 100, "offset": 0}
+        route = respx_mock.get("/diario/normas").mock(return_value=httpx.Response(200, json=page))
+        got = [n["numero"] for n in DiarioResource(sync_client).iter_all_normas()]
+        assert got == ["1", "2"]
+        assert route.call_count == 1
+
+
+class TestDiarioNormasAsync:
+    @pytest.mark.asyncio
+    async def test_list_normas(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        body = {"items": [{"numero": "21719"}], "total": 1, "limit": 20, "offset": 0}
+        route = respx_mock.get("/diario/normas").mock(return_value=httpx.Response(200, json=body))
+        result = await AsyncDiarioResource(async_client).list_normas(tipo="decreto_supremo")
+        assert result == body
+        assert route.called

--- a/tests/resources/test_equity.py
+++ b/tests/resources/test_equity.py
@@ -238,3 +238,36 @@ class TestEquityAsync:
         assert route.called
         params = dict(route.calls.last.request.url.params.multi_items())
         assert params == {"from": "2024-01-01"}
+
+
+class TestEquityForecast:
+    """v0.9.0 — GET /equity/{ticker}/forecast."""
+
+    def test_forecast_sync(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        body = {"ticker": "FALABELLA", "model": "timesfm-2.5-200m", "horizon": 3, "points": []}
+        route = respx_mock.get("/equity/FALABELLA/forecast").mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        result = EquityResource(sync_client).forecast("FALABELLA")
+        assert result == body
+        assert route.called
+
+    def test_forecast_encodes_ticker(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/equity/A%2FB/forecast").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        EquityResource(sync_client).forecast("A/B")
+        assert route.called
+
+    @pytest.mark.asyncio
+    async def test_forecast_async(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/equity/LTM/forecast").mock(
+            return_value=httpx.Response(200, json={"ticker": "LTM", "points": []})
+        )
+        result = await AsyncEquityResource(async_client).forecast("LTM")
+        assert result["ticker"] == "LTM"
+        assert route.called

--- a/tests/resources/test_legal.py
+++ b/tests/resources/test_legal.py
@@ -1,0 +1,89 @@
+"""Tests for ``cerberus_compliance.resources.legal`` (v0.9.0)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.legal import AsyncLegalResource, LegalResource
+
+
+class TestLegalMeta:
+    def test_sync_prefix(self) -> None:
+        assert LegalResource._path_prefix == "/legal/search"
+
+    def test_async_prefix(self) -> None:
+        assert AsyncLegalResource._path_prefix == "/legal/search"
+
+    def test_sync_subclass(self) -> None:
+        assert issubclass(LegalResource, BaseResource)
+
+    def test_async_subclass(self) -> None:
+        assert issubclass(AsyncLegalResource, AsyncBaseResource)
+
+
+class TestLegalSync:
+    def test_search_no_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        body = {
+            "items": [{"numero": "21719"}],
+            "next_cursor": None,
+            "prev_cursor": None,
+            "limit": 20,
+        }
+        route = respx_mock.get("/legal/search").mock(return_value=httpx.Response(200, json=body))
+        result = LegalResource(sync_client).search()
+        assert result == body
+        assert route.called
+        assert route.calls.last.request.url.query == b""
+
+    def test_search_with_filters(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get(
+            "/legal/search",
+            params={"q": "datos", "facetas": "proteccion_datos", "estado": "vigente", "limit": "5"},
+        ).mock(return_value=httpx.Response(200, json={"items": [], "next_cursor": None}))
+        LegalResource(sync_client).search(
+            q="datos", facetas="proteccion_datos", estado="vigente", limit=5
+        )
+        assert route.called
+
+    def test_iter_all_follows_cursor(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page1 = {"items": [{"numero": "1"}], "next_cursor": "C2"}
+        page2 = {"items": [{"numero": "2"}], "next_cursor": None}
+        respx_mock.get("/legal/search").mock(
+            side_effect=[httpx.Response(200, json=page1), httpx.Response(200, json=page2)]
+        )
+        got = list(LegalResource(sync_client).iter_all(q="x"))
+        assert [n["numero"] for n in got] == ["1", "2"]
+
+
+class TestLegalAsync:
+    @pytest.mark.asyncio
+    async def test_search(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        body = {"items": [{"numero": "21719"}], "next_cursor": None, "limit": 20}
+        route = respx_mock.get("/legal/search").mock(return_value=httpx.Response(200, json=body))
+        result = await AsyncLegalResource(async_client).search(q="ley")
+        assert result == body
+        assert route.called
+
+    @pytest.mark.asyncio
+    async def test_iter_all(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        page1 = {"items": [{"numero": "1"}], "next_cursor": "C2"}
+        page2 = {"items": [{"numero": "2"}], "next_cursor": None}
+        respx_mock.get("/legal/search").mock(
+            side_effect=[httpx.Response(200, json=page1), httpx.Response(200, json=page2)]
+        )
+        got = [n async for n in AsyncLegalResource(async_client).iter_all()]
+        assert [n["numero"] for n in got] == ["1", "2"]

--- a/tests/resources/test_regulatory_impact.py
+++ b/tests/resources/test_regulatory_impact.py
@@ -1,0 +1,64 @@
+"""Tests for ``cerberus_compliance.resources.regulatory_impact`` (v0.9.0)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.regulatory_impact import (
+    AsyncRegulatoryImpactResource,
+    RegulatoryImpactResource,
+)
+
+_ID = "a1b2c3d4-1111-2222-3333-444455556666"
+
+
+class TestRegulatoryImpactMeta:
+    def test_sync_prefix(self) -> None:
+        assert RegulatoryImpactResource._path_prefix == "/regulatory-impact"
+
+    def test_async_prefix(self) -> None:
+        assert AsyncRegulatoryImpactResource._path_prefix == "/regulatory-impact"
+
+    def test_sync_subclass(self) -> None:
+        assert issubclass(RegulatoryImpactResource, BaseResource)
+
+    def test_async_subclass(self) -> None:
+        assert issubclass(AsyncRegulatoryImpactResource, AsyncBaseResource)
+
+
+class TestRegulatoryImpactSync:
+    def test_get(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        body = {"id": _ID, "titulo": "Impacto NCG X", "severidad": "alta"}
+        route = respx_mock.get(f"/regulatory-impact/{_ID}").mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        result = RegulatoryImpactResource(sync_client).get(_ID)
+        assert result == body
+        assert route.called
+
+    def test_get_encodes_id(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulatory-impact/a%2Fb").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        RegulatoryImpactResource(sync_client).get("a/b")
+        assert route.called
+
+
+class TestRegulatoryImpactAsync:
+    @pytest.mark.asyncio
+    async def test_get(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        body = {"id": _ID, "titulo": "Impacto"}
+        route = respx_mock.get(f"/regulatory-impact/{_ID}").mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        result = await AsyncRegulatoryImpactResource(async_client).get(_ID)
+        assert result == body
+        assert route.called

--- a/tests/resources/test_regulatory_subscriptions.py
+++ b/tests/resources/test_regulatory_subscriptions.py
@@ -1,0 +1,95 @@
+"""Tests for ``cerberus_compliance.resources.regulatory_subscriptions`` (v0.9.0)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cerberus_compliance.client import AsyncCerberusClient, CerberusClient
+from cerberus_compliance.resources._base import AsyncBaseResource, BaseResource
+from cerberus_compliance.resources.regulatory_subscriptions import (
+    AsyncRegulatorySubscriptionsResource,
+    RegulatorySubscriptionsResource,
+)
+
+_PROFILE = {
+    "sectores_ciiu": ["64", "65"],
+    "secciones_rollup": ["Actividades financieras y de seguros"],
+    "materias": [],
+    "facetas": ["proteccion_datos"],
+    "fuentes": [],
+    "ruts": [],
+}
+
+
+class TestRegSubsMeta:
+    def test_sync_prefix(self) -> None:
+        assert RegulatorySubscriptionsResource._path_prefix == "/regulatory-subscriptions"
+
+    def test_async_prefix(self) -> None:
+        assert AsyncRegulatorySubscriptionsResource._path_prefix == "/regulatory-subscriptions"
+
+    def test_sync_subclass(self) -> None:
+        assert issubclass(RegulatorySubscriptionsResource, BaseResource)
+
+    def test_async_subclass(self) -> None:
+        assert issubclass(AsyncRegulatorySubscriptionsResource, AsyncBaseResource)
+
+
+class TestRegSubsSync:
+    def test_get(self, sync_client: CerberusClient, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.get("/regulatory-subscriptions").mock(
+            return_value=httpx.Response(200, json=_PROFILE)
+        )
+        result = RegulatorySubscriptionsResource(sync_client).get()
+        assert result == _PROFILE
+        assert route.called
+
+    def test_update_sends_only_provided_lists(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.put("/regulatory-subscriptions").mock(
+            return_value=httpx.Response(200, json=_PROFILE)
+        )
+        RegulatorySubscriptionsResource(sync_client).update(
+            sectores_ciiu=["64"], facetas=["proteccion_datos"]
+        )
+        assert route.called
+        sent = json.loads(route.calls.last.request.content)
+        # Solo las listas provistas viajan en el body (upsert parcial).
+        assert sent == {"sectores_ciiu": ["64"], "facetas": ["proteccion_datos"]}
+
+    def test_update_empty_body_when_nothing_provided(
+        self, sync_client: CerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.put("/regulatory-subscriptions").mock(
+            return_value=httpx.Response(200, json=_PROFILE)
+        )
+        RegulatorySubscriptionsResource(sync_client).update()
+        assert json.loads(route.calls.last.request.content) == {}
+
+
+class TestRegSubsAsync:
+    @pytest.mark.asyncio
+    async def test_get(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.get("/regulatory-subscriptions").mock(
+            return_value=httpx.Response(200, json=_PROFILE)
+        )
+        result = await AsyncRegulatorySubscriptionsResource(async_client).get()
+        assert result == _PROFILE
+        assert route.called
+
+    @pytest.mark.asyncio
+    async def test_update(
+        self, async_client: AsyncCerberusClient, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.put("/regulatory-subscriptions").mock(
+            return_value=httpx.Response(200, json=_PROFILE)
+        )
+        await AsyncRegulatorySubscriptionsResource(async_client).update(ruts=["76543210-9"])
+        assert json.loads(route.calls.last.request.content) == {"ruts": ["76543210-9"]}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,6 +10,14 @@ from __future__ import annotations
 import cerberus_compliance
 
 EXPECTED_ALL = {
+    # v0.9.0 — nuevas superficies (diario normas, legal search, regulatory).
+    "AsyncLegalResource",
+    "LegalResource",
+    "AsyncRegulatoryImpactResource",
+    "RegulatoryImpactResource",
+    "AsyncRegulatorySubscriptionsResource",
+    "RegulatorySubscriptionsResource",
+    "DiarioNormaTipo",
     # v0.7.0 — 18 new typed resources + 4 extensions (54 endpoints)
     "AsyncBankingResource",
     "AsyncCopilotResource",
@@ -129,8 +137,8 @@ EXPECTED_ALL = {
 }
 
 
-def test_version_is_v0_8_0() -> None:
-    assert cerberus_compliance.__version__.startswith("0.8.0")
+def test_version_is_v0_9_0() -> None:
+    assert cerberus_compliance.__version__.startswith("0.9.0")
 
 
 def test_all_matches_expected_surface() -> None:


### PR DESCRIPTION
## SDK 0.9.0

Cobertura de los endpoints nuevos de la API (drift vuelve a **0 uncovered / 0 rotten**, 120 covered contra prod):

- `client.diario.list_normas` / `iter_all_normas` — GET /diario/normas
- `client.equity.forecast` — GET /equity/{ticker}/forecast
- `client.legal.search` / `iter_all` — GET /legal/search (cursor)
- `client.regulatory_impact.get` — GET /regulatory-impact/{impact_id}
- `client.regulatory_subscriptions.get` / `update` — GET/PUT /regulatory-subscriptions

Sync + async. Salen de DEFERRED_COVERAGE los 4 regulatorios. Suite 1184 pass, cobertura 97.78%, ruff/mypy --strict limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)